### PR TITLE
feat: Redesign UI with amber/cream theme and DJ-inspired visuals

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       REFRESH_SECRET: ${REFRESH_SECRET:-dev-refresh-secret}
     user: "1000:1000"
     volumes:
-      - /mnt/music/cratedrop:/data:rw
+      - /mnt/ssd/apps/cratedrop:/data:rw
       - ./logs:/app/logs:rw
     ports:
       - "8080:8080" # direct access (optional); nginx proxies to this

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+*.log

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,12 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#121212" />
+    <meta name="theme-color" content="#0D0A14" />
     <title>CrateDrop</title>
+
+    <!-- Fonts: Clash Display + DM Sans -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap" rel="stylesheet">
+    <link href="https://api.fontshare.com/v2/css?f[]=clash-display@400,500,600,700&display=swap" rel="stylesheet">
   </head>
-  <body class="bg-[#121212]">
+  <body class="bg-crate-black">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
-  </html>
-
+</html>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,5 +1,5 @@
 import { NavLink, Outlet, Link, useLocation } from 'react-router-dom'
-import { Library, LogOut, Settings, UploadCloud, Folder, Menu, X, FolderOpen, Globe } from 'lucide-react'
+import { Library, LogOut, Settings, UploadCloud, Folder, Menu, X, FolderOpen, Globe, Disc } from 'lucide-react'
 import { useAuth } from '../../state/auth'
 import { PlayerBar } from '../player/PlayerBar'
 import { useCallback, useEffect, useState } from 'react'
@@ -56,37 +56,45 @@ export function Layout() {
   }, [addTracksMutation, toast])
 
   return (
-    <div className="min-h-screen grid grid-rows-[1fr_auto] overflow-visible">
+    <div className="min-h-screen grid grid-rows-[1fr_auto] overflow-visible bg-crate-black">
       {/* Mobile Header */}
-      <div className="lg:hidden fixed top-0 left-0 right-0 bg-[#181818] border-b border-[#2A2A2A] px-4 py-3 flex items-center justify-between z-40">
-        <div className="text-xl font-extrabold tracking-tight">CrateDrop</div>
+      <div className="lg:hidden fixed top-0 left-0 right-0 bg-crate-surface/95 backdrop-blur-md border-b border-crate-border px-4 py-3 flex items-center justify-between z-40">
+        <div className="flex items-center gap-2">
+          <Disc className="text-crate-amber" size={24} />
+          <span className="text-xl font-display font-bold text-crate-cream">CrateDrop</span>
+        </div>
         <button
           onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-          className="btn p-2"
+          className="hw-button p-2"
           aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
           aria-expanded={mobileMenuOpen}
         >
-          {mobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
+          {mobileMenuOpen ? <X size={20} /> : <Menu size={20} />}
         </button>
       </div>
 
       {/* Mobile Menu Overlay */}
       {mobileMenuOpen && (
-        <div className="lg:hidden fixed inset-0 bg-black bg-opacity-50 z-30" onClick={() => setMobileMenuOpen(false)} />
+        <div
+          className="lg:hidden fixed inset-0 bg-crate-black/80 backdrop-blur-sm z-30"
+          onClick={() => setMobileMenuOpen(false)}
+        />
       )}
 
       {/* Mobile Sidebar */}
-      <aside className={`lg:hidden fixed top-[57px] left-0 bottom-0 w-64 bg-[#181818] border-r border-[#2A2A2A] p-4 overflow-y-auto z-40 transform transition-transform ${mobileMenuOpen ? 'translate-x-0' : '-translate-x-full'}`}>
+      <aside className={`lg:hidden fixed top-[57px] left-0 bottom-0 w-72 bg-crate-surface border-r border-crate-border p-5 overflow-y-auto z-40 transform transition-transform duration-200 ${mobileMenuOpen ? 'translate-x-0' : '-translate-x-full'}`}>
         <nav className="space-y-1">
           <NavLink
             to="/"
             end
             className={({ isActive }) =>
-              `flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors ${isActive && !selectedCrateId ? 'bg-[#2A2A2A] text-white' : 'text-[#C1C1C1] hover:text-white hover:bg-[#202020]'
+              `flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-all ${isActive && !selectedCrateId
+                ? 'bg-crate-amber/10 text-crate-amber border border-crate-amber/20'
+                : 'text-crate-muted hover:text-crate-cream hover:bg-crate-elevated'
               }`
             }
           >
-            <span className="text-[#1DB954]"><Library size={18} /></span>
+            <Library size={18} />
             Library
           </NavLink>
           <NavItem to="/upload" label="Upload" icon={<UploadCloud size={18} />} />
@@ -94,52 +102,80 @@ export function Layout() {
           {user?.role === 'admin' && (
             <NavItem to="/admin" label="Admin" icon={<Settings size={18} />} />
           )}
-          <div className="mt-4 text-xs text-[#A1A1A1] px-3">Crates</div>
+
+          <div className="pt-6 pb-2">
+            <div className="text-xs font-medium text-crate-subtle uppercase tracking-wider px-4">
+              Your Crates
+            </div>
+          </div>
+
           <div className="space-y-1">
             {crates?.crates.map((p) => (
               <Link
                 key={p.id}
                 to={`/?crate=${p.id}`}
-                className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors ${selectedCrateId === p.id ? 'bg-[#2A2A2A] text-white' : 'text-[#C1C1C1] hover:text-white hover:bg-[#202020]'} ${dragOverCrateId === p.id && p.id !== 'unsorted' ? 'ring-2 ring-[#1DB954] bg-[#1DB954]/10' : ''}`}
+                className={`flex items-center gap-3 rounded-xl px-4 py-2.5 text-sm transition-all ${selectedCrateId === p.id
+                  ? 'bg-crate-amber/10 text-crate-amber border border-crate-amber/20'
+                  : 'text-crate-muted hover:text-crate-cream hover:bg-crate-elevated'
+                } ${dragOverCrateId === p.id && p.id !== 'unsorted'
+                  ? 'ring-2 ring-crate-cyan bg-crate-cyan/10'
+                  : ''
+                }`}
                 onDragOver={p.id !== 'unsorted' ? (e) => handleDragOver(e, p.id) : undefined}
                 onDragLeave={p.id !== 'unsorted' ? handleDragLeave : undefined}
                 onDrop={p.id !== 'unsorted' ? (e) => handleDrop(e, p.id) : undefined}
               >
-                <span className="text-[#1DB954]"><Folder size={16} /></span>
+                <Folder size={16} className={selectedCrateId === p.id ? 'text-crate-amber' : ''} />
                 <span className="truncate">{p.name}</span>
               </Link>
             ))}
-            <Link to="/crates" className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-[#A1A1A1] hover:text-white hover:bg-[#202020]">
-              <span className="text-[#1DB954]"><FolderOpen size={16} /></span>
+            <Link
+              to="/crates"
+              className="flex items-center gap-3 rounded-xl px-4 py-2.5 text-sm text-crate-subtle hover:text-crate-cream hover:bg-crate-elevated transition-all"
+            >
+              <FolderOpen size={16} />
               Manage Crates
             </Link>
           </div>
         </nav>
-        <div className="mt-8 text-xs text-[#A1A1A1]">Signed in as</div>
-        <div className="flex items-center justify-between mt-1">
-          <div className="text-sm truncate">{user?.email}</div>
-          <button className="btn btn-primary" onClick={logout} title="Logout">
-            <LogOut size={16} />
-          </button>
+
+        <div className="mt-8 pt-6 border-t border-crate-border">
+          <div className="text-xs text-crate-subtle mb-2">Signed in as</div>
+          <div className="flex items-center justify-between">
+            <div className="text-sm text-crate-cream truncate">{user?.email}</div>
+            <button
+              className="btn-ghost p-2 rounded-lg text-crate-muted hover:text-crate-danger"
+              onClick={logout}
+              title="Logout"
+            >
+              <LogOut size={16} />
+            </button>
+          </div>
         </div>
       </aside>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[220px_1fr] gap-6 p-3 sm:p-6 pt-20 lg:pt-6 overflow-visible">
+      <div className="grid grid-cols-1 lg:grid-cols-[260px_1fr] gap-6 p-4 sm:p-6 pt-20 lg:pt-6 overflow-visible">
         {/* Desktop Sidebar */}
-        <aside className="card p-4 hidden lg:block">
-          <div className="mb-6 flex items-center justify-between">
-            <div className="text-xl font-extrabold tracking-tight">CrateDrop</div>
+        <aside className="card p-5 hidden lg:block h-fit sticky top-6">
+          <div className="mb-8 flex items-center gap-3">
+            <div className="p-2 rounded-xl bg-crate-amber/10">
+              <Disc className="text-crate-amber" size={24} />
+            </div>
+            <span className="text-xl font-display font-bold text-crate-cream">CrateDrop</span>
           </div>
+
           <nav className="space-y-1">
             <NavLink
               to="/"
               end
               className={({ isActive }) =>
-                `flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors ${isActive && !selectedCrateId ? 'bg-[#2A2A2A] text-white' : 'text-[#C1C1C1] hover:text-white hover:bg-[#202020]'
+                `flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-all ${isActive && !selectedCrateId
+                  ? 'bg-crate-amber/10 text-crate-amber border border-crate-amber/20'
+                  : 'text-crate-muted hover:text-crate-cream hover:bg-crate-elevated'
                 }`
               }
             >
-              <span className="text-[#1DB954]"><Library size={18} /></span>
+              <Library size={18} />
               Library
             </NavLink>
             <NavItem to="/upload" label="Upload" icon={<UploadCloud size={18} />} />
@@ -147,60 +183,86 @@ export function Layout() {
             {user?.role === 'admin' && (
               <NavItem to="/admin" label="Admin" icon={<Settings size={18} />} />
             )}
-            <div className="mt-4 text-xs text-[#A1A1A1] px-3">Crates</div>
-            <div className="space-y-1">
+
+            <div className="pt-6 pb-2">
+              <div className="text-xs font-medium text-crate-subtle uppercase tracking-wider px-4">
+                Your Crates
+              </div>
+            </div>
+
+            <div className="space-y-1 max-h-64 overflow-y-auto">
               {crates?.crates.map((p) => (
                 <Link
                   key={p.id}
                   to={`/?crate=${p.id}`}
-                  className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors ${selectedCrateId === p.id ? 'bg-[#2A2A2A] text-white' : 'text-[#C1C1C1] hover:text-white hover:bg-[#202020]'} ${dragOverCrateId === p.id && p.id !== 'unsorted' ? 'ring-2 ring-[#1DB954] bg-[#1DB954]/10' : ''}`}
+                  className={`flex items-center gap-3 rounded-xl px-4 py-2.5 text-sm transition-all ${selectedCrateId === p.id
+                    ? 'bg-crate-amber/10 text-crate-amber border border-crate-amber/20'
+                    : 'text-crate-muted hover:text-crate-cream hover:bg-crate-elevated'
+                  } ${dragOverCrateId === p.id && p.id !== 'unsorted'
+                    ? 'ring-2 ring-crate-cyan bg-crate-cyan/10'
+                    : ''
+                  }`}
                   onDragOver={p.id !== 'unsorted' ? (e) => handleDragOver(e, p.id) : undefined}
                   onDragLeave={p.id !== 'unsorted' ? handleDragLeave : undefined}
                   onDrop={p.id !== 'unsorted' ? (e) => handleDrop(e, p.id) : undefined}
                 >
-                  <span className="text-[#1DB954]"><Folder size={16} /></span>
+                  <Folder size={16} className={selectedCrateId === p.id ? 'text-crate-amber' : ''} />
                   <span className="truncate">{p.name}</span>
                 </Link>
               ))}
-              <Link to="/crates" className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-[#A1A1A1] hover:text-white hover:bg-[#202020]">
-                <span className="text-[#1DB954]"><FolderOpen size={16} /></span>
+              <Link
+                to="/crates"
+                className="flex items-center gap-3 rounded-xl px-4 py-2.5 text-sm text-crate-subtle hover:text-crate-cream hover:bg-crate-elevated transition-all"
+              >
+                <FolderOpen size={16} />
                 Manage Crates
               </Link>
             </div>
           </nav>
-          <div className="mt-8 text-xs text-[#A1A1A1]">Signed in as</div>
-          <div className="flex items-center justify-between mt-1">
-            <div className="text-sm">{user?.email}</div>
-            <button className="btn btn-primary" onClick={logout} title="Logout">
-              <LogOut size={16} />
-            </button>
+
+          <div className="mt-8 pt-6 border-t border-crate-border">
+            <div className="text-xs text-crate-subtle mb-2">Signed in as</div>
+            <div className="flex items-center justify-between">
+              <div className="text-sm text-crate-cream truncate">{user?.email}</div>
+              <button
+                className="btn-ghost p-2 rounded-lg text-crate-muted hover:text-crate-danger transition-colors"
+                onClick={logout}
+                title="Logout"
+              >
+                <LogOut size={16} />
+              </button>
+            </div>
           </div>
         </aside>
-        <main className="space-y-6 overflow-visible">
+
+        <main className="space-y-6 overflow-visible animate-fade-in">
           <Outlet />
         </main>
       </div>
 
+      {/* Mobile drawer overlay */}
+      <div
+        className={`fixed inset-0 z-40 bg-crate-black/60 backdrop-blur-sm transition-opacity duration-200 lg:hidden ${mobileMenuOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+        onClick={() => setMobileMenuOpen(false)}
+      />
+
       {/* Mobile drawer */}
-      {(
-        <>
-          <div
-            className={`fixed inset-0 z-40 bg-black/60 transition-opacity duration-200 lg:hidden ${mobileMenuOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
-            onClick={() => setMobileMenuOpen(false)}
-          />
-          <div
-            className={`fixed inset-y-0 left-0 z-50 w-64 bg-[#181818] border-r border-[#2A2A2A] p-4 transform transition-transform duration-200 lg:hidden ${mobileMenuOpen ? 'translate-x-0' : '-translate-x-full'}`}
-          >
-            <div className="mb-6 flex items-center justify-between">
-              <div className="text-xl font-extrabold tracking-tight">CrateDrop</div>
-              <button className="btn" onClick={() => setMobileMenuOpen(false)} aria-label="Close menu">
-                <X size={18} />
-              </button>
+      <div
+        className={`fixed inset-y-0 left-0 z-50 w-72 bg-crate-surface border-r border-crate-border p-5 transform transition-transform duration-200 lg:hidden ${mobileMenuOpen ? 'translate-x-0' : '-translate-x-full'}`}
+      >
+        <div className="mb-8 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-xl bg-crate-amber/10">
+              <Disc className="text-crate-amber" size={24} />
             </div>
-            <SidebarContent user={user} logout={logout} onNavigate={() => setMobileMenuOpen(false)} />
+            <span className="text-xl font-display font-bold text-crate-cream">CrateDrop</span>
           </div>
-        </>
-      )}
+          <button className="hw-button p-2" onClick={() => setMobileMenuOpen(false)} aria-label="Close menu">
+            <X size={18} />
+          </button>
+        </div>
+        <SidebarContent user={user} logout={logout} onNavigate={() => setMobileMenuOpen(false)} />
+      </div>
 
       <PlayerBar />
     </div>
@@ -216,19 +278,21 @@ function SidebarContent({ user, logout, onNavigate }: { user: any; logout: () =>
           <NavItem to="/admin" label="Admin" icon={<Settings size={18} />} onClick={onNavigate} />
         )}
       </nav>
-      <div className="mt-8 text-xs text-[#A1A1A1]">Signed in as</div>
-      <div className="flex items-center justify-between mt-1">
-        <div className="text-sm">{user?.email}</div>
-        <button
-          className="btn btn-primary"
-          onClick={() => {
-            logout()
-            onNavigate?.()
-          }}
-          title="Logout"
-        >
-          <LogOut size={16} />
-        </button>
+      <div className="mt-8 pt-6 border-t border-crate-border">
+        <div className="text-xs text-crate-subtle mb-2">Signed in as</div>
+        <div className="flex items-center justify-between">
+          <div className="text-sm text-crate-cream">{user?.email}</div>
+          <button
+            className="btn-ghost p-2 rounded-lg text-crate-muted hover:text-crate-danger"
+            onClick={() => {
+              logout()
+              onNavigate?.()
+            }}
+            title="Logout"
+          >
+            <LogOut size={16} />
+          </button>
+        </div>
       </div>
     </>
   )
@@ -240,14 +304,15 @@ function NavItem({ to, label, icon, onClick }: { to: string; label: string; icon
       to={to}
       end
       className={({ isActive }) =>
-        `flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors ${isActive ? 'bg-[#2A2A2A] text-white' : 'text-[#C1C1C1] hover:text-white hover:bg-[#202020]'
+        `flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-all ${isActive
+          ? 'bg-crate-amber/10 text-crate-amber border border-crate-amber/20'
+          : 'text-crate-muted hover:text-crate-cream hover:bg-crate-elevated'
         }`
       }
       onClick={onClick}
     >
-      <span className="text-[#1DB954]">{icon}</span>
+      {icon}
       {label}
     </NavLink>
   )
 }
-

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { useEffect, useState } from 'react'
+import { Users, HardDrive, Disc } from 'lucide-react'
 
 type User = {
   id: string
@@ -18,12 +19,10 @@ export function AdminPage() {
       const [usersRes] = await Promise.all([
         axios.get('/api/users'),
       ])
-      // Ensure we always set an array, even if the response is malformed
       const usersData = usersRes.data?.users || usersRes.data || []
       setUsers(Array.isArray(usersData) ? usersData : [])
     } catch (error) {
       console.error('Failed to fetch admin data:', error)
-      // Set empty arrays on error to prevent map errors
       setUsers([])
     } finally {
       setLoading(false)
@@ -34,9 +33,6 @@ export function AdminPage() {
     fetchData()
   }, [])
 
-
-
-  // Helper function to format storage bytes to human-readable format
   function formatStorage(bytes?: number): string {
     if (!bytes || bytes === 0) return '0 B'
     const gb = bytes / (1024 * 1024 * 1024)
@@ -48,29 +44,98 @@ export function AdminPage() {
     return `${bytes} B`
   }
 
+  const totalStorage = users.reduce((acc, u) => acc + (u.storage_bytes || 0), 0)
+
   return (
     <div className="space-y-6">
-      <div className="text-xl font-bold">Admin</div>
-      <div className="card p-4">
-        <div className="font-semibold mb-2">Users</div>
+      {/* Header */}
+      <div>
+        <h1 className="text-3xl font-display font-bold text-crate-cream">Admin</h1>
+        <p className="text-crate-muted mt-1">Manage users and monitor system usage</p>
+      </div>
+
+      {/* Stats cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="card p-5">
+          <div className="flex items-center gap-4">
+            <div className="p-3 rounded-xl bg-crate-cyan/10">
+              <Users size={24} className="text-crate-cyan" />
+            </div>
+            <div>
+              <div className="text-sm text-crate-muted">Total Users</div>
+              <div className="text-2xl font-display font-bold text-crate-cream">
+                {loading ? '—' : users.length}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="card p-5">
+          <div className="flex items-center gap-4">
+            <div className="p-3 rounded-xl bg-crate-amber/10">
+              <HardDrive size={24} className="text-crate-amber" />
+            </div>
+            <div>
+              <div className="text-sm text-crate-muted">Total Storage</div>
+              <div className="text-2xl font-display font-bold text-crate-cream">
+                {loading ? '—' : formatStorage(totalStorage)}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Users table */}
+      <div className="card overflow-hidden">
+        <div className="p-5 border-b border-crate-border">
+          <h2 className="text-lg font-display font-semibold text-crate-cream">Users</h2>
+        </div>
+
         {loading ? (
-          <div className="text-sm text-[#A1A1A1]">Loading…</div>
+          <div className="flex items-center justify-center gap-3 py-12">
+            <Disc className="text-crate-amber vinyl-spinning" size={24} />
+            <span className="text-crate-muted">Loading users...</span>
+          </div>
+        ) : users.length === 0 ? (
+          <div className="text-center py-12">
+            <Users size={32} className="mx-auto text-crate-subtle mb-3" />
+            <p className="text-crate-muted">No users found</p>
+          </div>
         ) : (
           <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+            <table className="w-full">
               <thead>
-                <tr className="border-b border-[#2A2A2A]">
-                  <th className="text-left py-2 px-2">Email</th>
-                  <th className="text-left py-2 px-2">Role</th>
-                  <th className="text-right py-2 px-2">Storage</th>
+                <tr className="border-b border-crate-border bg-crate-elevated/50">
+                  <th className="text-left py-3 px-5 text-xs uppercase tracking-wider text-crate-subtle font-medium">
+                    Email
+                  </th>
+                  <th className="text-left py-3 px-5 text-xs uppercase tracking-wider text-crate-subtle font-medium">
+                    Role
+                  </th>
+                  <th className="text-right py-3 px-5 text-xs uppercase tracking-wider text-crate-subtle font-medium">
+                    Storage
+                  </th>
                 </tr>
               </thead>
-              <tbody>
-                {Array.isArray(users) && users.map((u) => (
-                  <tr key={u.id} className="border-b border-[#1A1A1A]">
-                    <td className="py-2 px-2">{u.email}</td>
-                    <td className="py-2 px-2 text-[#A1A1A1]">{u.role}</td>
-                    <td className="py-2 px-2 text-right text-[#A1A1A1]">{formatStorage(u.storage_bytes)}</td>
+              <tbody className="divide-y divide-crate-border/50">
+                {users.map((u, idx) => (
+                  <tr
+                    key={u.id}
+                    className="stagger-item hover:bg-crate-elevated/30 transition-colors"
+                    style={{ animationDelay: `${idx * 30}ms` }}
+                  >
+                    <td className="py-4 px-5 text-crate-cream">{u.email}</td>
+                    <td className="py-4 px-5">
+                      <span className={`inline-flex px-2.5 py-1 rounded-lg text-xs font-medium ${u.role === 'admin'
+                        ? 'bg-crate-amber/10 text-crate-amber'
+                        : 'bg-crate-elevated text-crate-muted'
+                        }`}>
+                        {u.role}
+                      </span>
+                    </td>
+                    <td className="py-4 px-5 text-right text-crate-muted tabular-nums">
+                      {formatStorage(u.storage_bytes)}
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -81,4 +146,3 @@ export function AdminPage() {
     </div>
   )
 }
-

--- a/frontend/src/pages/CommunityPage.tsx
+++ b/frontend/src/pages/CommunityPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Globe, Music, Play, Pause, User } from 'lucide-react'
+import { Globe, Music, Play, Pause, User, ChevronDown, ChevronUp, Disc } from 'lucide-react'
 import { communityApi, cratesApi } from '../lib/api'
 import type { PlaylistWithOwner } from '../types/crates'
 import { usePlayer } from '../state/player'
@@ -14,7 +14,7 @@ export function CommunityPage() {
     const [loading, setLoading] = useState(true)
     const [expandedCrate, setExpandedCrate] = useState<string | null>(null)
     const [loadingTracks, setLoadingTracks] = useState<string | null>(null)
-    const { play, queue, index } = usePlayer()
+    const { play, queue, index, isPlaying, toggle } = usePlayer()
 
     useEffect(() => {
         fetchPublicCrates()
@@ -44,7 +44,6 @@ export function CommunityPage() {
 
         setExpandedCrate(crateId)
 
-        // Fetch tracks if not already loaded
         const crate = crates.find(c => c.id === crateId)
         if (crate && !crate.tracks) {
             setLoadingTracks(crateId)
@@ -64,110 +63,144 @@ export function CommunityPage() {
     }
 
     const handlePlayTrack = (track: any, crateId: string) => {
-        play({
-            id: track.id,
-            title: track.title || track.original_filename,
-            artist: track.artist || 'Unknown Artist',
-            streamUrl: `/api/tracks/${track.id}/stream`,
-            durationSeconds: track.duration_seconds
-        }, true)
+        const currentTrack = queue[index]
+        if (currentTrack?.id === track.id) {
+            toggle()
+        } else {
+            play({
+                id: track.id,
+                title: track.title || track.original_filename,
+                artist: track.artist || 'Unknown Artist',
+                streamUrl: `/api/tracks/${track.id}/stream`,
+                durationSeconds: track.duration_seconds
+            }, true)
+        }
     }
 
     if (loading) {
         return (
-            <div className="flex items-center justify-center py-12">
-                <div className="text-[#A1A1A1]">Loading community crates...</div>
+            <div className="flex flex-col items-center justify-center py-16">
+                <Disc className="text-crate-amber vinyl-spinning-slow mb-4" size={48} />
+                <div className="text-crate-muted">Loading community crates...</div>
             </div>
         )
     }
 
     return (
         <div className="space-y-6">
-            <div className="flex items-center justify-between">
+            {/* Header */}
+            <div className="flex items-center gap-4">
+                <div className="p-3 rounded-xl bg-crate-cyan/10">
+                    <Globe size={24} className="text-crate-cyan" />
+                </div>
                 <div>
-                    <div className="flex items-center gap-2">
-                        <Globe size={24} className="text-[#1DB954]" />
-                        <h1 className="text-2xl font-bold">Community</h1>
-                    </div>
-                    <p className="text-[#A1A1A1] mt-1">Browse public crates from other users</p>
+                    <h1 className="text-3xl font-display font-bold text-crate-cream">Community</h1>
+                    <p className="text-crate-muted mt-1">Browse public crates from other users</p>
                 </div>
             </div>
 
+            {/* Empty state */}
             {crates.length === 0 ? (
-                <div className="text-center py-12">
-                    <Music size={48} className="mx-auto text-[#A1A1A1] mb-4" />
-                    <h3 className="text-lg font-semibold mb-2">No public crates yet</h3>
-                    <p className="text-[#A1A1A1]">No users have shared their crates publicly</p>
+                <div className="text-center py-16">
+                    <div className="w-24 h-24 mx-auto mb-6 rounded-full bg-crate-elevated flex items-center justify-center">
+                        <Music size={40} className="text-crate-subtle" />
+                    </div>
+                    <h3 className="text-xl font-display font-semibold text-crate-cream mb-2">No public crates yet</h3>
+                    <p className="text-crate-muted">No users have shared their crates publicly</p>
                 </div>
             ) : (
                 <div className="space-y-4">
-                    {crates.map((crate) => (
-                        <div key={crate.id} className="card p-4">
+                    {crates.map((crate, idx) => (
+                        <div
+                            key={crate.id}
+                            className="stagger-item card overflow-hidden transition-all"
+                            style={{ animationDelay: `${idx * 50}ms` }}
+                        >
+                            {/* Crate header */}
                             <div
-                                className="flex items-start justify-between cursor-pointer"
+                                className="p-5 flex items-start justify-between cursor-pointer hover:bg-crate-elevated/30 transition-colors"
                                 onClick={() => toggleCrateExpansion(crate.id)}
                             >
-                                <div className="flex items-center gap-3 flex-1">
-                                    <div className="w-12 h-12 bg-gradient-to-br from-[#1DB954] to-[#1ed760] rounded-lg flex items-center justify-center">
-                                        <Music size={24} className="text-black" />
+                                <div className="flex items-center gap-4 flex-1 min-w-0">
+                                    <div className="w-14 h-14 rounded-xl bg-gradient-to-br from-crate-cyan to-crate-cyanDark flex items-center justify-center flex-shrink-0 shadow-glow-cyan">
+                                        <Music size={24} className="text-crate-black" />
                                     </div>
                                     <div className="flex-1 min-w-0">
-                                        <h3 className="font-semibold truncate">{crate.name}</h3>
-                                        <p className="text-sm text-[#A1A1A1] truncate">
+                                        <h3 className="font-display font-semibold text-crate-cream truncate">
+                                            {crate.name}
+                                        </h3>
+                                        <p className="text-sm text-crate-muted truncate mt-0.5">
                                             {crate.description || 'No description'}
                                         </p>
-                                        <div className="flex items-center gap-2 mt-1">
-                                            <User size={12} className="text-[#A1A1A1]" />
-                                            <span className="text-xs text-[#A1A1A1]">{crate.owner_email}</span>
+                                        <div className="flex items-center gap-2 mt-2">
+                                            <User size={12} className="text-crate-subtle" />
+                                            <span className="text-xs text-crate-subtle">{crate.owner_email}</span>
                                         </div>
                                     </div>
                                 </div>
-                                <span className="text-xs bg-[#1DB954]/20 text-[#1DB954] px-2 py-1 rounded">
-                                    Public
-                                </span>
+
+                                <div className="flex items-center gap-3 flex-shrink-0">
+                                    <span className="text-xs bg-crate-cyan/10 text-crate-cyan px-3 py-1.5 rounded-lg font-medium">
+                                        Public
+                                    </span>
+                                    {expandedCrate === crate.id ? (
+                                        <ChevronUp size={18} className="text-crate-muted" />
+                                    ) : (
+                                        <ChevronDown size={18} className="text-crate-muted" />
+                                    )}
+                                </div>
                             </div>
 
                             {/* Expanded tracks view */}
                             {expandedCrate === crate.id && (
-                                <div className="mt-4 pt-4 border-t border-[#2A2A2A]">
+                                <div className="border-t border-crate-border bg-crate-elevated/20">
                                     {loadingTracks === crate.id ? (
-                                        <div className="text-center py-4 text-[#A1A1A1]">
-                                            Loading tracks...
+                                        <div className="flex items-center justify-center gap-3 py-8">
+                                            <Disc className="text-crate-amber vinyl-spinning" size={24} />
+                                            <span className="text-crate-muted">Loading tracks...</span>
                                         </div>
                                     ) : crate.tracks && crate.tracks.length > 0 ? (
-                                        <div className="space-y-2">
-                                            {crate.tracks.map((track: any) => (
-                                                <div
-                                                    key={track.id}
-                                                    className="flex items-center justify-between p-2 hover:bg-[#2A2A2A] rounded group"
-                                                >
-                                                    <div className="flex-1 min-w-0">
-                                                        <div className="font-medium truncate">
-                                                            {track.title || track.original_filename}
-                                                        </div>
-                                                        <div className="text-sm text-[#A1A1A1] truncate">
-                                                            {track.artist || 'Unknown Artist'}
+                                        <div className="divide-y divide-crate-border/50">
+                                            {crate.tracks.map((track: any) => {
+                                                const isCurrent = queue[index]?.id === track.id
+                                                const isCurrentAndPlaying = isCurrent && isPlaying
+
+                                                return (
+                                                    <div
+                                                        key={track.id}
+                                                        className={`flex items-center justify-between px-5 py-3 hover:bg-crate-elevated/50 transition-colors group ${isCurrent ? 'bg-crate-amber/5' : ''}`}
+                                                    >
+                                                        <div className="flex items-center gap-3 flex-1 min-w-0">
+                                                            <button
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation()
+                                                                    handlePlayTrack(track, crate.id)
+                                                                }}
+                                                                className={`hw-button p-2 flex-shrink-0 ${isCurrentAndPlaying ? 'hw-button-primary' : 'opacity-0 group-hover:opacity-100'} transition-opacity`}
+                                                            >
+                                                                {isCurrentAndPlaying ? (
+                                                                    <Pause size={14} />
+                                                                ) : (
+                                                                    <Play size={14} className="ml-0.5" />
+                                                                )}
+                                                            </button>
+                                                            <div className="min-w-0">
+                                                                <div className={`font-medium truncate ${isCurrent ? 'text-crate-amber' : 'text-crate-cream'}`}>
+                                                                    {track.title || track.original_filename}
+                                                                </div>
+                                                                <div className="text-sm text-crate-muted truncate">
+                                                                    {track.artist || 'Unknown Artist'}
+                                                                </div>
+                                                            </div>
                                                         </div>
                                                     </div>
-                                                    <button
-                                                        onClick={(e) => {
-                                                            e.stopPropagation()
-                                                            handlePlayTrack(track, crate.id)
-                                                        }}
-                                                        className="p-2 hover:bg-[#1DB954]/20 rounded-full transition-colors"
-                                                    >
-                                                        {queue[index]?.id === track.id ? (
-                                                            <Pause size={18} className="text-[#1DB954]" />
-                                                        ) : (
-                                                            <Play size={18} className="text-[#1DB954]" />
-                                                        )}
-                                                    </button>
-                                                </div>
-                                            ))}
+                                                )
+                                            })}
                                         </div>
                                     ) : (
-                                        <div className="text-center py-4 text-[#A1A1A1]">
-                                            No tracks in this crate
+                                        <div className="text-center py-8">
+                                            <Music size={24} className="mx-auto text-crate-subtle mb-2" />
+                                            <p className="text-crate-muted text-sm">No tracks in this crate</p>
                                         </div>
                                     )}
                                 </div>

--- a/frontend/src/pages/CratesPage.tsx
+++ b/frontend/src/pages/CratesPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useSearchParams, useNavigate } from 'react-router-dom'
-import { Plus, Edit, Trash2, Music, MoreHorizontal, Globe, Lock } from 'lucide-react'
+import { Plus, Edit, Trash2, Music, MoreHorizontal, Globe, Lock, Disc } from 'lucide-react'
 import { Crate, CreateCrateRequest, UpdateCrateRequest } from '../types/crates'
 import { useToast } from '../hooks/useToast'
 import { useCrates, useCreateCrate, useUpdateCrate, useDeleteCrate, useAddTracksToCrate } from '../hooks/useQueries'
@@ -128,18 +128,20 @@ export function CratesPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <div className="text-[#A1A1A1]">Loading crates...</div>
+      <div className="flex flex-col items-center justify-center py-16">
+        <Disc className="text-crate-amber vinyl-spinning-slow mb-4" size={48} />
+        <div className="text-crate-muted">Loading crates...</div>
       </div>
     )
   }
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold">Your Crates</h1>
-          <p className="text-[#A1A1A1] mt-1">Organize your music into custom crates</p>
+          <h1 className="text-3xl font-display font-bold text-crate-cream">Your Crates</h1>
+          <p className="text-crate-muted mt-1">Organize your music into custom crates</p>
         </div>
         <button
           onClick={() => setShowCreateModal(true)}
@@ -150,238 +152,260 @@ export function CratesPage() {
         </button>
       </div>
 
+      {/* Crate grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {crates?.crates.filter(c => c.id !== 'unsorted').map((crate) => (
+        {crates?.crates.filter(c => c.id !== 'unsorted').map((crate, idx) => (
           <div
             key={crate.id}
-            className={`card p-4 group transition-all relative cursor-pointer hover:bg-[#202020] ${dragOverCrateId === crate.id ? 'ring-2 ring-[#1DB954] bg-[#1DB954]/10' : ''}`}
+            className={`stagger-item card p-5 group transition-all relative cursor-pointer hover:shadow-glow ${dragOverCrateId === crate.id ? 'ring-2 ring-crate-cyan shadow-glow-cyan' : ''}`}
+            style={{ animationDelay: `${idx * 50}ms` }}
             onDragOver={(e) => handleDragOver(e, crate.id)}
             onDragLeave={handleDragLeave}
             onDrop={(e) => handleDrop(e, crate.id)}
             onClick={() => navigate(`/?crate=${crate.id}`)}
           >
-            <div className="flex items-start justify-between mb-3">
-              <div className="flex items-center gap-3 flex-1">
-                <div className="w-12 h-12 bg-[#1DB954] rounded-lg flex items-center justify-center">
-                  <Music size={24} className="text-black" />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <h3 className="font-semibold truncate">{crate.name}</h3>
-                  <p className="text-sm text-[#A1A1A1] truncate">
-                    {crate.description || 'No description'}
-                  </p>
-                  {crate.is_default && (
-                    <span className="text-xs bg-[#2A2A2A] px-2 py-1 rounded mt-1 inline-block">
-                      Default
-                    </span>
-                  )}
-                </div>
+            <div className="flex items-start gap-4">
+              {/* Crate icon */}
+              <div className="w-14 h-14 rounded-xl bg-gradient-to-br from-crate-amber to-crate-amberDark flex items-center justify-center flex-shrink-0 shadow-glow">
+                <Music size={24} className="text-crate-black" />
               </div>
 
-              <div className="absolute top-4 right-12">
-                {crate.is_public ? (
-                  <Globe size={16} className="text-[#A1A1A1]" />
-                ) : (
-                  <Lock size={16} className="text-[#A1A1A1]" />
-                )}
-              </div>
+              {/* Content */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <h3 className="font-display font-semibold text-crate-cream truncate">
+                      {crate.name}
+                    </h3>
+                    <p className="text-sm text-crate-muted truncate mt-0.5">
+                      {crate.description || 'No description'}
+                    </p>
+                  </div>
 
-              {!crate.is_default && (
-                <div className="relative">
-                  <button
-                    className="p-1 hover:bg-[#2A2A2A] rounded"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      setMenuOpen(menuOpen === crate.id ? null : crate.id)
-                    }}
-                  >
-                    <MoreHorizontal size={16} />
-                  </button>
-
-                  {menuOpen === crate.id && (
-                    <div className="crate-menu absolute right-0 mt-1 w-32 bg-[#1A1A1A] rounded-lg shadow-lg border border-[#2A2A2A] py-1 z-50">
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          startEdit(crate)
-                          setMenuOpen(null)
-                        }}
-                        className="w-full text-left px-3 py-2 text-sm hover:bg-[#2A2A2A] flex items-center gap-2"
-                      >
-                        <Edit size={14} />
-                        Edit
-                      </button>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          handleDelete(crate)
-                          setMenuOpen(null)
-                        }}
-                        className="w-full text-left px-3 py-2 text-sm hover:bg-[#2A2A2A] flex items-center gap-2 text-red-400"
-                      >
-                        <Trash2 size={14} />
-                        Delete
-                      </button>
+                  {/* Status badges */}
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    <div className={`p-1.5 rounded-lg ${crate.is_public ? 'bg-crate-cyan/10 text-crate-cyan' : 'bg-crate-elevated text-crate-subtle'}`}>
+                      {crate.is_public ? <Globe size={14} /> : <Lock size={14} />}
                     </div>
-                  )}
-                </div>
-              )}
-            </div>
 
-            <div className="text-xs text-[#A1A1A1]">
-              Created {new Date(crate.created_at).toLocaleDateString()}
+                    {!crate.is_default && (
+                      <div className="relative">
+                        <button
+                          className="p-1.5 rounded-lg hover:bg-crate-elevated text-crate-muted hover:text-crate-cream transition-colors"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setMenuOpen(menuOpen === crate.id ? null : crate.id)
+                          }}
+                        >
+                          <MoreHorizontal size={14} />
+                        </button>
+
+                        {menuOpen === crate.id && (
+                          <div className="crate-menu absolute right-0 mt-1 w-36 bg-crate-elevated rounded-xl shadow-elevated border border-crate-border py-1 z-50">
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                startEdit(crate)
+                                setMenuOpen(null)
+                              }}
+                              className="w-full text-left px-3 py-2 text-sm text-crate-cream hover:bg-crate-border flex items-center gap-2 transition-colors"
+                            >
+                              <Edit size={14} />
+                              Edit
+                            </button>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation()
+                                handleDelete(crate)
+                                setMenuOpen(null)
+                              }}
+                              className="w-full text-left px-3 py-2 text-sm text-crate-danger hover:bg-crate-danger/10 flex items-center gap-2 transition-colors"
+                            >
+                              <Trash2 size={14} />
+                              Delete
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Metadata */}
+                <div className="flex items-center gap-3 mt-3 text-xs text-crate-subtle">
+                  {crate.is_default && (
+                    <span className="px-2 py-1 rounded-md bg-crate-elevated">Default</span>
+                  )}
+                  <span>Created {new Date(crate.created_at).toLocaleDateString()}</span>
+                </div>
+              </div>
             </div>
           </div>
         ))}
       </div>
 
-      {
-        (!crates?.crates.length || crates.crates.filter(c => c.id !== 'unsorted').length === 0) && (
-          <div className="text-center py-12">
-            <Music size={48} className="mx-auto text-[#A1A1A1] mb-4" />
-            <h3 className="text-lg font-semibold mb-2">No crates yet</h3>
-            <p className="text-[#A1A1A1] mb-4">Create your first crate to start organizing your music</p>
-            <button
-              onClick={() => setShowCreateModal(true)}
-              className="btn btn-primary"
-            >
-              Create Your First Crate
-            </button>
+      {/* Empty state */}
+      {(!crates?.crates.length || crates.crates.filter(c => c.id !== 'unsorted').length === 0) && (
+        <div className="text-center py-16">
+          <div className="w-24 h-24 mx-auto mb-6 rounded-full bg-crate-elevated flex items-center justify-center">
+            <Music size={40} className="text-crate-subtle" />
           </div>
-        )
-      }
+          <h3 className="text-xl font-display font-semibold text-crate-cream mb-2">No crates yet</h3>
+          <p className="text-crate-muted mb-6">Create your first crate to start organizing your music</p>
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="btn btn-primary"
+          >
+            Create Your First Crate
+          </button>
+        </div>
+      )}
 
       {/* Create Crate Modal */}
-      {
-        showCreateModal && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-            <div className="bg-[#1A1A1A] rounded-lg p-6 w-full max-w-md">
-              <h2 className="text-xl font-bold mb-4">Create New Crate</h2>
+      {showCreateModal && (
+        <div className="fixed inset-0 bg-crate-black/80 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+          <div className="bg-crate-surface border border-crate-border rounded-2xl p-6 w-full max-w-md shadow-elevated animate-slide-up">
+            <h2 className="text-xl font-display font-bold text-crate-cream mb-6">Create New Crate</h2>
 
-              <form onSubmit={handleCreate} className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium mb-1">Name *</label>
-                  <input
-                    type="text"
-                    value={createForm.name}
-                    onChange={(e) => setCreateForm({ ...createForm, name: e.target.value })}
-                    className="input w-full"
-                    placeholder="My Awesome Playlist"
-                    required
-                  />
-                </div>
+            <form onSubmit={handleCreate} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-crate-cream mb-2">Name *</label>
+                <input
+                  type="text"
+                  value={createForm.name}
+                  onChange={(e) => setCreateForm({ ...createForm, name: e.target.value })}
+                  className="input w-full"
+                  placeholder="My Awesome Playlist"
+                  required
+                  autoFocus
+                />
+              </div>
 
-                <div>
-                  <label className="block text-sm font-medium mb-1">Description</label>
-                  <textarea
-                    value={createForm.description}
-                    onChange={(e) => setCreateForm({ ...createForm, description: e.target.value })}
-                    className="input w-full h-24 resize-none"
-                    placeholder="Optional description..."
-                  />
-                </div>
+              <div>
+                <label className="block text-sm font-medium text-crate-cream mb-2">Description</label>
+                <textarea
+                  value={createForm.description}
+                  onChange={(e) => setCreateForm({ ...createForm, description: e.target.value })}
+                  className="input w-full h-24 resize-none"
+                  placeholder="Optional description..."
+                />
+              </div>
 
-                <div className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    id="create-public"
-                    checked={createForm.is_public}
-                    onChange={(e) => setCreateForm({ ...createForm, is_public: e.target.checked })}
-                    className="rounded bg-[#2A2A2A] border-none text-[#1DB954] focus:ring-[#1DB954]"
-                  />
-                  <label htmlFor="create-public" className="text-sm font-medium cursor-pointer select-none flex items-center gap-2">
-                    {createForm.is_public ? <Globe size={14} /> : <Lock size={14} />}
-                    {createForm.is_public ? 'Public Crate' : 'Private Crate'}
-                  </label>
-                </div>
+              <div className="flex items-center gap-3 p-3 rounded-xl bg-crate-elevated">
+                <input
+                  type="checkbox"
+                  id="create-public"
+                  checked={createForm.is_public}
+                  onChange={(e) => setCreateForm({ ...createForm, is_public: e.target.checked })}
+                />
+                <label htmlFor="create-public" className="flex items-center gap-2 text-sm font-medium text-crate-cream cursor-pointer select-none">
+                  {createForm.is_public ? (
+                    <>
+                      <Globe size={16} className="text-crate-cyan" />
+                      Public Crate
+                    </>
+                  ) : (
+                    <>
+                      <Lock size={16} className="text-crate-muted" />
+                      Private Crate
+                    </>
+                  )}
+                </label>
+              </div>
 
-                <div className="flex gap-3 pt-2">
-                  <button type="submit" className="btn btn-primary flex-1">
-                    Create Crate
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setShowCreateModal(false)
-                      setCreateForm({ name: '', description: '', is_public: true })
-                      const next = new URLSearchParams(searchParams)
-                      next.delete('create')
-                      setSearchParams(next, { replace: true })
-                    }}
-                    className="btn flex-1"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </form>
-            </div>
+              <div className="flex gap-3 pt-4">
+                <button type="submit" className="btn btn-primary flex-1">
+                  Create Crate
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowCreateModal(false)
+                    setCreateForm({ name: '', description: '', is_public: true })
+                    const next = new URLSearchParams(searchParams)
+                    next.delete('create')
+                    setSearchParams(next, { replace: true })
+                  }}
+                  className="btn flex-1"
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
           </div>
-        )
-      }
+        </div>
+      )}
 
       {/* Edit Crate Modal */}
-      {
-        editingCrate && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-            <div className="bg-[#1A1A1A] rounded-lg p-6 w-full max-w-md">
-              <h2 className="text-xl font-bold mb-4">Edit Crate</h2>
+      {editingCrate && (
+        <div className="fixed inset-0 bg-crate-black/80 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+          <div className="bg-crate-surface border border-crate-border rounded-2xl p-6 w-full max-w-md shadow-elevated animate-slide-up">
+            <h2 className="text-xl font-display font-bold text-crate-cream mb-6">Edit Crate</h2>
 
-              <form onSubmit={handleUpdate} className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium mb-1">Name *</label>
-                  <input
-                    type="text"
-                    value={updateForm.name}
-                    onChange={(e) => setUpdateForm({ ...updateForm, name: e.target.value })}
-                    className="input w-full"
-                    required
-                  />
-                </div>
+            <form onSubmit={handleUpdate} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-crate-cream mb-2">Name *</label>
+                <input
+                  type="text"
+                  value={updateForm.name}
+                  onChange={(e) => setUpdateForm({ ...updateForm, name: e.target.value })}
+                  className="input w-full"
+                  required
+                  autoFocus
+                />
+              </div>
 
-                <div>
-                  <label className="block text-sm font-medium mb-1">Description</label>
-                  <textarea
-                    value={updateForm.description}
-                    onChange={(e) => setUpdateForm({ ...updateForm, description: e.target.value })}
-                    className="input w-full h-24 resize-none"
-                    placeholder="Optional description..."
-                  />
-                </div>
+              <div>
+                <label className="block text-sm font-medium text-crate-cream mb-2">Description</label>
+                <textarea
+                  value={updateForm.description}
+                  onChange={(e) => setUpdateForm({ ...updateForm, description: e.target.value })}
+                  className="input w-full h-24 resize-none"
+                  placeholder="Optional description..."
+                />
+              </div>
 
-                <div className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    id="update-public"
-                    checked={updateForm.is_public}
-                    onChange={(e) => setUpdateForm({ ...updateForm, is_public: e.target.checked })}
-                    className="rounded bg-[#2A2A2A] border-none text-[#1DB954] focus:ring-[#1DB954]"
-                  />
-                  <label htmlFor="update-public" className="text-sm font-medium cursor-pointer select-none flex items-center gap-2">
-                    {updateForm.is_public ? <Globe size={14} /> : <Lock size={14} />}
-                    {updateForm.is_public ? 'Public Crate' : 'Private Crate'}
-                  </label>
-                </div>
+              <div className="flex items-center gap-3 p-3 rounded-xl bg-crate-elevated">
+                <input
+                  type="checkbox"
+                  id="update-public"
+                  checked={updateForm.is_public}
+                  onChange={(e) => setUpdateForm({ ...updateForm, is_public: e.target.checked })}
+                />
+                <label htmlFor="update-public" className="flex items-center gap-2 text-sm font-medium text-crate-cream cursor-pointer select-none">
+                  {updateForm.is_public ? (
+                    <>
+                      <Globe size={16} className="text-crate-cyan" />
+                      Public Crate
+                    </>
+                  ) : (
+                    <>
+                      <Lock size={16} className="text-crate-muted" />
+                      Private Crate
+                    </>
+                  )}
+                </label>
+              </div>
 
-                <div className="flex gap-3 pt-2">
-                  <button type="submit" className="btn btn-primary flex-1">
-                    Update Crate
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setEditingCrate(null)
-                      setUpdateForm({ name: '', description: '', is_public: true })
-                    }}
-                    className="btn flex-1"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </form>
-            </div>
+              <div className="flex gap-3 pt-4">
+                <button type="submit" className="btn btn-primary flex-1">
+                  Update Crate
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingCrate(null)
+                    setUpdateForm({ name: '', description: '', is_public: true })
+                  }}
+                  className="btn flex-1"
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
           </div>
-        )
-      }
-    </div >
+        </div>
+      )}
+    </div>
   )
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '../state/auth'
+import { Disc } from 'lucide-react'
 
 export function LoginPage() {
   const { login } = useAuth()
@@ -25,29 +26,87 @@ export function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen grid place-items-center p-6">
-      <div className="card w-full max-w-md p-6">
-        <div className="text-2xl font-extrabold mb-1">Welcome back</div>
-        <div className="text-sm text-[#A1A1A1] mb-6">Sign in to your library</div>
-        <form className="space-y-4" onSubmit={onSubmit}>
+    <div className="min-h-screen grid place-items-center p-6 bg-crate-black relative overflow-hidden">
+      {/* Background decoration */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div
+          className="absolute -top-1/4 -left-1/4 w-1/2 h-1/2 rounded-full opacity-20"
+          style={{
+            background: 'radial-gradient(circle, rgba(229, 160, 0, 0.3) 0%, transparent 70%)',
+          }}
+        />
+        <div
+          className="absolute -bottom-1/4 -right-1/4 w-1/2 h-1/2 rounded-full opacity-10"
+          style={{
+            background: 'radial-gradient(circle, rgba(0, 212, 255, 0.3) 0%, transparent 70%)',
+          }}
+        />
+      </div>
+
+      <div className="card w-full max-w-md p-8 relative z-10 animate-slide-up">
+        {/* Logo */}
+        <div className="flex items-center justify-center gap-3 mb-8">
+          <div className="p-3 rounded-xl bg-crate-amber/10">
+            <Disc className="text-crate-amber" size={32} />
+          </div>
+          <span className="text-2xl font-display font-bold text-crate-cream">CrateDrop</span>
+        </div>
+
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-display font-bold text-crate-cream mb-2">Welcome back</h1>
+          <p className="text-crate-muted">Sign in to your library</p>
+        </div>
+
+        <form className="space-y-5" onSubmit={onSubmit}>
           <div>
-            <label className="block text-sm mb-1">Email</label>
-            <input className="input w-full" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+            <label className="block text-sm font-medium text-crate-cream mb-2">Email</label>
+            <input
+              className="input w-full"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              required
+              autoFocus
+            />
           </div>
           <div>
-            <label className="block text-sm mb-1">Password</label>
-            <input className="input w-full" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+            <label className="block text-sm font-medium text-crate-cream mb-2">Password</label>
+            <input
+              className="input w-full"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="••••••••"
+              required
+            />
           </div>
-          {error && <div className="text-red-400 text-sm">{error}</div>}
+
+          {error && (
+            <div className="p-3 rounded-xl bg-crate-danger/10 border border-crate-danger/20 text-crate-danger text-sm">
+              {error}
+            </div>
+          )}
+
           <button className="btn btn-primary w-full" disabled={loading}>
-            {loading ? 'Signing in...' : 'Sign in'}
+            {loading ? (
+              <span className="flex items-center gap-2">
+                <Disc className="vinyl-spinning" size={18} />
+                Signing in...
+              </span>
+            ) : (
+              'Sign in'
+            )}
           </button>
         </form>
-        <div className="mt-4 text-sm text-[#A1A1A1] text-center">
-          Don't have an account? <Link className="link" to="/signup">Sign up</Link>
+
+        <div className="mt-6 pt-6 border-t border-crate-border text-center">
+          <span className="text-sm text-crate-muted">
+            Don't have an account?{' '}
+            <Link className="link" to="/signup">Sign up</Link>
+          </span>
         </div>
       </div>
     </div>
   )
 }
-

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '../state/auth'
+import { Disc } from 'lucide-react'
 
 export function SignupPage() {
   const { signup } = useAuth()
@@ -25,29 +26,87 @@ export function SignupPage() {
   }
 
   return (
-    <div className="min-h-screen grid place-items-center p-6">
-      <div className="card w-full max-w-md p-6">
-        <div className="text-2xl font-extrabold mb-1">Create your account</div>
-        <div className="text-sm text-[#A1A1A1] mb-6">Sign up to start building your music library</div>
-        <form className="space-y-4" onSubmit={onSubmit}>
+    <div className="min-h-screen grid place-items-center p-6 bg-crate-black relative overflow-hidden">
+      {/* Background decoration */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div
+          className="absolute -top-1/4 -right-1/4 w-1/2 h-1/2 rounded-full opacity-20"
+          style={{
+            background: 'radial-gradient(circle, rgba(0, 212, 255, 0.3) 0%, transparent 70%)',
+          }}
+        />
+        <div
+          className="absolute -bottom-1/4 -left-1/4 w-1/2 h-1/2 rounded-full opacity-10"
+          style={{
+            background: 'radial-gradient(circle, rgba(229, 160, 0, 0.3) 0%, transparent 70%)',
+          }}
+        />
+      </div>
+
+      <div className="card w-full max-w-md p-8 relative z-10 animate-slide-up">
+        {/* Logo */}
+        <div className="flex items-center justify-center gap-3 mb-8">
+          <div className="p-3 rounded-xl bg-crate-amber/10">
+            <Disc className="text-crate-amber" size={32} />
+          </div>
+          <span className="text-2xl font-display font-bold text-crate-cream">CrateDrop</span>
+        </div>
+
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-display font-bold text-crate-cream mb-2">Create your account</h1>
+          <p className="text-crate-muted">Start building your music library</p>
+        </div>
+
+        <form className="space-y-5" onSubmit={onSubmit}>
           <div>
-            <label className="block text-sm mb-1">Email</label>
-            <input className="input w-full" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+            <label className="block text-sm font-medium text-crate-cream mb-2">Email</label>
+            <input
+              className="input w-full"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              required
+              autoFocus
+            />
           </div>
           <div>
-            <label className="block text-sm mb-1">Password</label>
-            <input className="input w-full" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+            <label className="block text-sm font-medium text-crate-cream mb-2">Password</label>
+            <input
+              className="input w-full"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="••••••••"
+              required
+            />
           </div>
-          {error && <div className="text-red-400 text-sm">{error}</div>}
+
+          {error && (
+            <div className="p-3 rounded-xl bg-crate-danger/10 border border-crate-danger/20 text-crate-danger text-sm">
+              {error}
+            </div>
+          )}
+
           <button className="btn btn-primary w-full" disabled={loading}>
-            {loading ? 'Creating account...' : 'Sign up'}
+            {loading ? (
+              <span className="flex items-center gap-2">
+                <Disc className="vinyl-spinning" size={18} />
+                Creating account...
+              </span>
+            ) : (
+              'Sign up'
+            )}
           </button>
         </form>
-        <div className="mt-4 text-sm text-[#A1A1A1]">
-          Already have an account? <Link className="link" to="/login">Sign in</Link>
+
+        <div className="mt-6 pt-6 border-t border-crate-border text-center">
+          <span className="text-sm text-crate-muted">
+            Already have an account?{' '}
+            <Link className="link" to="/login">Sign in</Link>
+          </span>
         </div>
       </div>
     </div>
   )
 }
-

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -11,34 +11,208 @@ html, body, #root {
 }
 
 body {
-  background-color: #121212;
-  color: #EDEDED;
+  background-color: #0D0A14;
+  color: #F5F0E8;
+  font-family: 'DM Sans', system-ui, sans-serif;
 }
 
+/* Grain texture overlay */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.7' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+  opacity: 0.03;
+  pointer-events: none;
+  z-index: 9999;
+}
+
+/* Typography */
+h1, h2, h3, h4, h5, h6, .font-display {
+  font-family: 'Clash Display', system-ui, sans-serif;
+}
+
+/* Base button styles */
 .btn {
-  @apply inline-flex items-center justify-center rounded-full px-4 py-2 font-semibold transition-colors duration-200;
+  @apply inline-flex items-center justify-center rounded-xl px-4 py-2.5 font-medium transition-all duration-200 ease-out;
+  @apply bg-crate-elevated border border-crate-border text-crate-cream;
+  @apply hover:bg-crate-border hover:border-crate-subtle active:scale-[0.98];
 }
 
 .btn-primary {
-  @apply bg-[#1DB954] text-black hover:bg-[#1ed760] focus:outline-none focus:ring-2 focus:ring-[#1DB954]/40;
+  @apply bg-crate-amber text-crate-black border-transparent;
+  @apply hover:bg-crate-amberLight hover:shadow-glow;
+  @apply focus:outline-none focus:ring-2 focus:ring-crate-amber/40 focus:ring-offset-2 focus:ring-offset-crate-black;
 }
 
+.btn-ghost {
+  @apply bg-transparent border-transparent text-crate-muted;
+  @apply hover:bg-crate-elevated hover:text-crate-cream;
+}
+
+.btn-danger {
+  @apply bg-crate-danger/10 border-crate-danger/30 text-crate-danger;
+  @apply hover:bg-crate-danger/20 hover:border-crate-danger/50;
+}
+
+/* Card styles */
 .card {
-  @apply bg-[#181818] rounded-xl border border-[#2A2A2A] shadow-glow;
+  @apply bg-crate-surface rounded-2xl border border-crate-border;
+  @apply shadow-card backdrop-blur-sm;
+  transition: all 0.2s ease-out;
 }
 
+.card:hover {
+  @apply border-crate-subtle;
+}
+
+.card-elevated {
+  @apply bg-crate-elevated;
+}
+
+/* Input styles */
 .input {
-  @apply bg-[#181818] border border-[#2A2A2A] rounded-lg px-3 py-2 text-sm placeholder:text-[#7A7A7A] focus:outline-none focus:ring-2 focus:ring-[#1DB954]/30;
+  @apply bg-crate-elevated border border-crate-border rounded-xl px-4 py-2.5;
+  @apply text-crate-cream placeholder:text-crate-subtle;
+  @apply focus:outline-none focus:ring-2 focus:ring-crate-amber/30 focus:border-crate-amber/50;
+  @apply transition-all duration-200;
 }
 
+.input:hover {
+  @apply border-crate-subtle;
+}
+
+/* Link styles */
 .link {
-  @apply text-[#1DB954] hover:underline;
+  @apply text-crate-amber hover:text-crate-amberLight underline-offset-2 hover:underline;
+  @apply transition-colors duration-200;
 }
 
-/* Minor mobile tweaks */
-@media (max-width: 640px) {
-  .card {
-    border-radius: 12px;
+/* Vinyl record animation */
+@keyframes vinyl-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.vinyl-spinning {
+  animation: vinyl-spin 3s linear infinite;
+}
+
+.vinyl-spinning-slow {
+  animation: vinyl-spin 8s linear infinite;
+}
+
+/* VU meter progress bar */
+.vu-meter {
+  @apply h-1.5 rounded-full overflow-hidden;
+  background: linear-gradient(90deg,
+    rgba(229, 160, 0, 0.1) 0%,
+    rgba(229, 160, 0, 0.2) 100%
+  );
+}
+
+.vu-meter-fill {
+  @apply h-full rounded-full transition-all duration-100;
+  background: linear-gradient(90deg,
+    #E5A000 0%,
+    #FFB82E 70%,
+    #00D4FF 100%
+  );
+  box-shadow: 0 0 10px rgba(229, 160, 0, 0.5);
+}
+
+/* Hardware button style */
+.hw-button {
+  @apply relative inline-flex items-center justify-center;
+  @apply rounded-full p-3 transition-all duration-150;
+  @apply bg-crate-elevated border-2 border-crate-border;
+  @apply hover:border-crate-subtle hover:bg-crate-border;
+  @apply active:scale-95;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.hw-button-primary {
+  @apply bg-crate-amber border-crate-amberDark text-crate-black;
+  @apply hover:bg-crate-amberLight hover:border-crate-amber;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    0 2px 12px rgba(229, 160, 0, 0.3);
+}
+
+/* Scrollbar styling */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #332E3C;
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #4A4454;
+}
+
+/* Selection styling */
+::selection {
+  background: rgba(229, 160, 0, 0.3);
+  color: #F5F0E8;
+}
+
+/* Focus visible styling */
+:focus-visible {
+  outline: 2px solid rgba(229, 160, 0, 0.5);
+  outline-offset: 2px;
+}
+
+/* Checkbox styling */
+input[type="checkbox"] {
+  @apply w-4 h-4 rounded bg-crate-elevated border-crate-border;
+  @apply checked:bg-crate-amber checked:border-crate-amber;
+  @apply focus:ring-2 focus:ring-crate-amber/30 focus:ring-offset-0;
+}
+
+/* Staggered animation for lists */
+.stagger-item {
+  animation: slide-up 0.4s ease-out backwards;
+}
+
+.stagger-item:nth-child(1) { animation-delay: 0ms; }
+.stagger-item:nth-child(2) { animation-delay: 30ms; }
+.stagger-item:nth-child(3) { animation-delay: 60ms; }
+.stagger-item:nth-child(4) { animation-delay: 90ms; }
+.stagger-item:nth-child(5) { animation-delay: 120ms; }
+.stagger-item:nth-child(6) { animation-delay: 150ms; }
+.stagger-item:nth-child(7) { animation-delay: 180ms; }
+.stagger-item:nth-child(8) { animation-delay: 210ms; }
+.stagger-item:nth-child(9) { animation-delay: 240ms; }
+.stagger-item:nth-child(10) { animation-delay: 270ms; }
+
+@keyframes slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 
+/* Mobile adjustments */
+@media (max-width: 640px) {
+  .card {
+    @apply rounded-xl;
+  }
+
+  .btn {
+    @apply px-3 py-2;
+  }
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -6,32 +6,72 @@ export default {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        display: ['Clash Display', 'system-ui', 'sans-serif'],
+        body: ['DM Sans', 'system-ui', 'sans-serif'],
+      },
       colors: {
-        spotify: {
-          green: "#1DB954",
-          black: "#121212",
-          dark: "#0B0B0B",
-          gray: {
-            100: "#F1F1F1",
-            200: "#E1E1E1",
-            300: "#C1C1C1",
-            400: "#A1A1A1",
-            500: "#7A7A7A",
-            600: "#535353",
-            700: "#3E3E3E",
-            800: "#2A2A2A",
-            900: "#181818"
-          }
+        crate: {
+          // Base surfaces
+          black: "#0D0A14",
+          surface: "#1A171F",
+          elevated: "#252130",
+          border: "#332E3C",
+
+          // Accent colors
+          amber: "#E5A000",
+          amberLight: "#FFB82E",
+          amberDark: "#B37D00",
+          cyan: "#00D4FF",
+          cyanDark: "#00A8CC",
+
+          // Text
+          cream: "#F5F0E8",
+          muted: "#9B95A3",
+          subtle: "#6B6573",
+
+          // Semantic
+          danger: "#FF6B6B",
+          success: "#4ADE80",
         }
       },
       borderRadius: {
-        xl: "14px",
+        'xl': "12px",
+        '2xl': "16px",
+        '3xl': "24px",
       },
       boxShadow: {
-        glow: "0 0 0 1px rgba(29,185,84,0.2), 0 8px 24px rgba(0,0,0,0.25)",
-      }
+        'glow': '0 0 20px rgba(229, 160, 0, 0.15)',
+        'glow-strong': '0 0 30px rgba(229, 160, 0, 0.25)',
+        'glow-cyan': '0 0 20px rgba(0, 212, 255, 0.15)',
+        'elevated': '0 8px 32px rgba(0, 0, 0, 0.4)',
+        'card': '0 4px 24px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.03)',
+      },
+      animation: {
+        'spin-slow': 'spin 3s linear infinite',
+        'spin-slower': 'spin 8s linear infinite',
+        'pulse-glow': 'pulse-glow 2s ease-in-out infinite',
+        'fade-in': 'fade-in 0.3s ease-out',
+        'slide-up': 'slide-up 0.4s ease-out',
+      },
+      keyframes: {
+        'pulse-glow': {
+          '0%, 100%': { opacity: '0.6' },
+          '50%': { opacity: '1' },
+        },
+        'fade-in': {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
+        'slide-up': {
+          '0%': { opacity: '0', transform: 'translateY(10px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+      },
+      backgroundImage: {
+        'grain': "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E\")",
+      },
     },
   },
   plugins: [],
 }
-


### PR DESCRIPTION
## Summary

- Replace Spotify green theme with warm amber/cream color system
- Add Clash Display and DM Sans typography
- Create spinning vinyl record component in PlayerBar
- Add VU meter style progress bars with gradient fill
- Implement grain texture overlay and glow effects
- Add hardware-style button components
- Update all pages with new design tokens
- Add staggered list animations

## Changes

**New Design System:**
- Base colors: `crate-black`, `crate-surface`, `crate-elevated`, `crate-border`
- Accent colors: `crate-amber`, `crate-cyan`
- Text colors: `crate-cream`, `crate-muted`, `crate-subtle`

**New Components:**
- `VinylRecord` - Animated spinning vinyl disc in PlayerBar
- `.hw-button` - Hardware-style transport controls
- `.vu-meter` - VU meter progress bars

**Visual Effects:**
- Grain texture overlay on body
- Glow effects on buttons and active elements
- Staggered fade-in animations on lists
- Backdrop blur on player bar

## Test plan

- [ ] Verify all pages render with new color scheme
- [ ] Test vinyl animation spins when track is playing
- [ ] Test VU meter progress bar responds to seek
- [ ] Verify mobile responsive layouts work correctly
- [ ] Check fonts load correctly (Clash Display, DM Sans)

🤖 Generated with [Claude Code](https://claude.com/claude-code)