### PR TITLE
feat: Add Spotify integration for syncing liked songs

### DIFF
--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -115,5 +115,18 @@ func (d *DB) migrate() error {
 		}
 	}
 
+	// Check if spotify_sync_config table exists
+	var spTableCount int
+	_ = d.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='spotify_sync_config'").Scan(&spTableCount)
+	if spTableCount == 0 {
+		migrationSQL, err := migrationsFS.ReadFile("migrations/003_add_spotify_sync.sql")
+		if err != nil {
+			return fmt.Errorf("failed to read migration 003_add_spotify_sync: %w", err)
+		}
+		if _, err := d.Exec(string(migrationSQL)); err != nil {
+			return fmt.Errorf("failed to execute migration 003_add_spotify_sync: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/backend/internal/db/migrations/003_add_spotify_sync.sql
+++ b/backend/internal/db/migrations/003_add_spotify_sync.sql
@@ -1,0 +1,56 @@
+-- Spotify Sync Configuration (Singleton table for admin)
+CREATE TABLE IF NOT EXISTS spotify_sync_config (
+    id INTEGER PRIMARY KEY DEFAULT 1,
+    access_token TEXT,
+    refresh_token TEXT,
+    token_expires_at DATETIME,
+    owner_user_id TEXT NOT NULL,
+    liked_songs_playlist_id TEXT,
+    enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    last_sync_at DATETIME,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (liked_songs_playlist_id) REFERENCES playlists(id) ON DELETE SET NULL,
+    CHECK (id = 1)
+);
+
+-- Sync history for tracking sync runs
+CREATE TABLE IF NOT EXISTS spotify_sync_history (
+    id TEXT PRIMARY KEY,
+    sync_started_at DATETIME NOT NULL,
+    sync_completed_at DATETIME,
+    tracks_added INTEGER DEFAULT 0,
+    tracks_skipped INTEGER DEFAULT 0,
+    error_message TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_spotify_sync_history_started
+    ON spotify_sync_history(sync_started_at DESC);
+
+-- Track external IDs to avoid re-downloading
+CREATE TABLE IF NOT EXISTS spotify_synced_tracks (
+    id TEXT PRIMARY KEY,
+    spotify_id TEXT NOT NULL UNIQUE,
+    track_id TEXT NOT NULL,
+    synced_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (track_id) REFERENCES tracks(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_spotify_synced_tracks_sp_id
+    ON spotify_synced_tracks(spotify_id);
+
+-- Spotify playlists that are being synced
+CREATE TABLE IF NOT EXISTS spotify_synced_playlists (
+    id TEXT PRIMARY KEY,
+    spotify_playlist_id TEXT NOT NULL UNIQUE,
+    local_playlist_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    last_sync_at DATETIME,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (local_playlist_id) REFERENCES playlists(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_spotify_synced_playlists_sp_id
+    ON spotify_synced_playlists(spotify_playlist_id);

--- a/backend/main.go
+++ b/backend/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/faraz525/home-music-server/backend/playlists"
 	"github.com/faraz525/home-music-server/backend/server"
 	"github.com/faraz525/home-music-server/backend/soundcloud"
+	"github.com/faraz525/home-music-server/backend/spotify"
 	"github.com/faraz525/home-music-server/backend/tracks"
 )
 
@@ -67,6 +68,18 @@ func main() {
 	)
 	fmt.Printf("[CrateDrop] SoundCloud sync manager initialized\n")
 
+	// Initialize Spotify sync manager
+	spotifyRepo := spotify.NewRepository(db)
+	spotifyManager := spotify.NewManager(
+		spotifyRepo,
+		tracksRepo,
+		storage,
+		extractor,
+		playlistsManager,
+		cfg.DataDir,
+	)
+	fmt.Printf("[CrateDrop] Spotify sync manager initialized\n")
+
 	// Initialize router and API group
 	r, api := server.NewRouter()
 
@@ -77,10 +90,12 @@ func main() {
 	tracks.Routes(tracksManager, playlistsManager)(protected)
 	playlists.Routes(playlistsManager)(protected)
 	soundcloud.Routes(soundcloudManager)(protected)
+	spotify.Routes(spotifyManager)(protected)
 
-	// Start SoundCloud sync loop in background
+	// Start sync loops in background
 	ctx := context.Background()
 	go soundcloud.StartSyncLoop(ctx, soundcloudManager)
+	go spotify.StartSyncLoop(ctx, spotifyManager)
 
 	addr := "0.0.0.0:" + cfg.Port
 	fmt.Printf("[CrateDrop] Server listening on http://%s\n", addr)

--- a/backend/spotify/handlers.go
+++ b/backend/spotify/handlers.go
@@ -57,8 +57,7 @@ func (h *Handlers) UpdateConfig(c *gin.Context) {
 		return
 	}
 
-	// Get the user ID from the context (set by auth middleware)
-	userID, exists := c.Get("userID")
+	userID, exists := c.Get("user_id")
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": gin.H{"code": "unauthorized", "message": "user not authenticated"}})
 		return
@@ -85,7 +84,7 @@ func (h *Handlers) ExchangeToken(c *gin.Context) {
 		return
 	}
 
-	userID, exists := c.Get("userID")
+	userID, exists := c.Get("user_id")
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": gin.H{"code": "unauthorized", "message": "user not authenticated"}})
 		return

--- a/backend/spotify/handlers.go
+++ b/backend/spotify/handlers.go
@@ -1,0 +1,157 @@
+package spotify
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Handlers struct {
+	manager *Manager
+}
+
+func NewHandlers(manager *Manager) *Handlers {
+	return &Handlers{manager: manager}
+}
+
+func (h *Handlers) GetConfig(c *gin.Context) {
+	cfg, err := h.manager.GetSyncConfig(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "internal_error", "message": err.Error()}})
+		return
+	}
+
+	clientID := h.manager.GetClientID()
+
+	if cfg == nil {
+		c.JSON(http.StatusOK, gin.H{
+			"configured": false,
+			"enabled":    false,
+			"client_id":  clientID,
+		})
+		return
+	}
+
+	hasToken := cfg.AccessToken != nil && *cfg.AccessToken != ""
+
+	c.JSON(http.StatusOK, gin.H{
+		"configured":              hasToken,
+		"enabled":                 cfg.Enabled,
+		"owner_user_id":           cfg.OwnerUserID,
+		"liked_songs_playlist_id": cfg.LikedSongsPlaylistID,
+		"last_sync_at":            cfg.LastSyncAt,
+		"client_id":               clientID,
+	})
+}
+
+type UpdateConfigRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+func (h *Handlers) UpdateConfig(c *gin.Context) {
+	var req UpdateConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_request", "message": err.Error()}})
+		return
+	}
+
+	// Get the user ID from the context (set by auth middleware)
+	userID, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": gin.H{"code": "unauthorized", "message": "user not authenticated"}})
+		return
+	}
+
+	if err := h.manager.SaveSyncConfig(c.Request.Context(), userID.(string), req.Enabled); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "internal_error", "message": err.Error()}})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "config updated"})
+}
+
+type TokenExchangeRequest struct {
+	Code         string `json:"code" binding:"required"`
+	CodeVerifier string `json:"code_verifier" binding:"required"`
+	RedirectURI  string `json:"redirect_uri" binding:"required"`
+}
+
+func (h *Handlers) ExchangeToken(c *gin.Context) {
+	var req TokenExchangeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_request", "message": err.Error()}})
+		return
+	}
+
+	userID, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": gin.H{"code": "unauthorized", "message": "user not authenticated"}})
+		return
+	}
+
+	if err := h.manager.ExchangeCodeForToken(c.Request.Context(), req.Code, req.CodeVerifier, req.RedirectURI, userID.(string)); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "token_exchange_failed", "message": err.Error()}})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "connected to Spotify"})
+}
+
+func (h *Handlers) Disconnect(c *gin.Context) {
+	if err := h.manager.Disconnect(c.Request.Context()); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "internal_error", "message": err.Error()}})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "disconnected from Spotify"})
+}
+
+func (h *Handlers) TriggerSync(c *gin.Context) {
+	go func() {
+		if err := h.manager.SyncLikes(context.Background()); err != nil {
+			fmt.Printf("[Spotify] Manual sync failed: %v\n", err)
+		}
+	}()
+
+	c.JSON(http.StatusAccepted, gin.H{"message": "sync triggered"})
+}
+
+func (h *Handlers) GetHistory(c *gin.Context) {
+	history, err := h.manager.GetSyncHistory(c.Request.Context(), 20)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "internal_error", "message": err.Error()}})
+		return
+	}
+
+	if history == nil {
+		history = []*SyncHistory{}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"history": history})
+}
+
+func (h *Handlers) GetPlaylists(c *gin.Context) {
+	playlists, err := h.manager.FetchUserPlaylists(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "internal_error", "message": err.Error()}})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"playlists": playlists})
+}
+
+func (h *Handlers) GetSyncedPlaylists(c *gin.Context) {
+	playlists, err := h.manager.GetSyncedPlaylists(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "internal_error", "message": err.Error()}})
+		return
+	}
+
+	if playlists == nil {
+		playlists = []*SyncedPlaylist{}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"playlists": playlists})
+}

--- a/backend/spotify/manager.go
+++ b/backend/spotify/manager.go
@@ -631,10 +631,12 @@ func (m *Manager) GetSyncedPlaylists(ctx context.Context) ([]*SyncedPlaylist, er
 	return m.repo.GetSyncedPlaylists(ctx)
 }
 
-// Disconnect removes the Spotify connection
 func (m *Manager) Disconnect(ctx context.Context) error {
 	cfg, err := m.repo.GetSyncConfig(ctx)
-	if err != nil || cfg == nil {
+	if err != nil {
+		return fmt.Errorf("failed to get sync config: %w", err)
+	}
+	if cfg == nil {
 		return nil
 	}
 

--- a/backend/spotify/manager.go
+++ b/backend/spotify/manager.go
@@ -1,0 +1,647 @@
+package spotify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/faraz525/home-music-server/backend/internal/media/metadata"
+	imodels "github.com/faraz525/home-music-server/backend/internal/models"
+	"github.com/faraz525/home-music-server/backend/internal/storage"
+	"github.com/faraz525/home-music-server/backend/playlists"
+	"github.com/faraz525/home-music-server/backend/tracks"
+	"github.com/faraz525/home-music-server/backend/utils"
+)
+
+const (
+	SpotifyAuthURL  = "https://accounts.spotify.com/authorize"
+	SpotifyTokenURL = "https://accounts.spotify.com/api/token"
+	SpotifyAPIURL   = "https://api.spotify.com/v1"
+)
+
+type Manager struct {
+	repo             *Repository
+	tracksRepo       *tracks.Repository
+	storage          storage.Storage
+	extractor        metadata.Extractor
+	playlistsManager *playlists.Manager
+	dataDir          string
+	clientID         string
+	syncMutex        sync.Mutex
+}
+
+func NewManager(
+	repo *Repository,
+	tracksRepo *tracks.Repository,
+	storage storage.Storage,
+	extractor metadata.Extractor,
+	pm *playlists.Manager,
+	dataDir string,
+) *Manager {
+	clientID := os.Getenv("SPOTIFY_CLIENT_ID")
+	return &Manager{
+		repo:             repo,
+		tracksRepo:       tracksRepo,
+		storage:          storage,
+		extractor:        extractor,
+		playlistsManager: pm,
+		dataDir:          dataDir,
+		clientID:         clientID,
+	}
+}
+
+func (m *Manager) GetClientID() string {
+	return m.clientID
+}
+
+func (m *Manager) GetSyncConfig(ctx context.Context) (*SyncConfig, error) {
+	return m.repo.GetSyncConfig(ctx)
+}
+
+func (m *Manager) SaveSyncConfig(ctx context.Context, ownerUserID string, enabled bool) error {
+	cfg := &SyncConfig{
+		OwnerUserID: ownerUserID,
+		Enabled:     enabled,
+	}
+
+	existing, _ := m.repo.GetSyncConfig(ctx)
+	if existing != nil {
+		cfg.AccessToken = existing.AccessToken
+		cfg.RefreshToken = existing.RefreshToken
+		cfg.TokenExpiresAt = existing.TokenExpiresAt
+		cfg.LikedSongsPlaylistID = existing.LikedSongsPlaylistID
+	}
+
+	return m.repo.UpsertSyncConfig(ctx, cfg)
+}
+
+func (m *Manager) GetSyncHistory(ctx context.Context, limit int) ([]*SyncHistory, error) {
+	if limit <= 0 || limit > 50 {
+		limit = 10
+	}
+	return m.repo.GetSyncHistory(ctx, limit)
+}
+
+// ExchangeCodeForToken exchanges an authorization code for access and refresh tokens using PKCE
+func (m *Manager) ExchangeCodeForToken(ctx context.Context, code, codeVerifier, redirectURI, ownerUserID string) error {
+	data := url.Values{}
+	data.Set("grant_type", "authorization_code")
+	data.Set("code", code)
+	data.Set("redirect_uri", redirectURI)
+	data.Set("client_id", m.clientID)
+	data.Set("code_verifier", codeVerifier)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", SpotifyTokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to exchange token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+		TokenType    string `json:"token_type"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+
+	cfg := &SyncConfig{
+		AccessToken:    &tokenResp.AccessToken,
+		RefreshToken:   &tokenResp.RefreshToken,
+		TokenExpiresAt: &expiresAt,
+		OwnerUserID:    ownerUserID,
+		Enabled:        false, // User must explicitly enable
+	}
+
+	// Preserve existing playlist ID if config exists
+	existing, _ := m.repo.GetSyncConfig(ctx)
+	if existing != nil {
+		cfg.LikedSongsPlaylistID = existing.LikedSongsPlaylistID
+		cfg.Enabled = existing.Enabled
+	}
+
+	return m.repo.UpsertSyncConfig(ctx, cfg)
+}
+
+// RefreshAccessToken refreshes the access token using the refresh token
+func (m *Manager) RefreshAccessToken(ctx context.Context) error {
+	cfg, err := m.repo.GetSyncConfig(ctx)
+	if err != nil || cfg == nil || cfg.RefreshToken == nil {
+		return fmt.Errorf("no refresh token available")
+	}
+
+	data := url.Values{}
+	data.Set("grant_type", "refresh_token")
+	data.Set("refresh_token", *cfg.RefreshToken)
+	data.Set("client_id", m.clientID)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", SpotifyTokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to refresh token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("token refresh failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return fmt.Errorf("failed to parse refresh response: %w", err)
+	}
+
+	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+
+	// If no new refresh token is provided, keep the old one
+	refreshToken := *cfg.RefreshToken
+	if tokenResp.RefreshToken != "" {
+		refreshToken = tokenResp.RefreshToken
+	}
+
+	return m.repo.UpdateTokens(ctx, tokenResp.AccessToken, refreshToken, expiresAt)
+}
+
+// getValidToken returns a valid access token, refreshing if necessary
+func (m *Manager) getValidToken(ctx context.Context) (string, error) {
+	cfg, err := m.repo.GetSyncConfig(ctx)
+	if err != nil || cfg == nil {
+		return "", fmt.Errorf("spotify not configured")
+	}
+
+	if cfg.AccessToken == nil || *cfg.AccessToken == "" {
+		return "", fmt.Errorf("no access token")
+	}
+
+	// Refresh if token expires in the next 5 minutes
+	if cfg.TokenExpiresAt != nil && time.Until(*cfg.TokenExpiresAt) < 5*time.Minute {
+		if err := m.RefreshAccessToken(ctx); err != nil {
+			return "", fmt.Errorf("failed to refresh token: %w", err)
+		}
+		// Reload config after refresh
+		cfg, _ = m.repo.GetSyncConfig(ctx)
+	}
+
+	return *cfg.AccessToken, nil
+}
+
+// SpotifyTrack represents a track from Spotify API
+type SpotifyTrack struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Artists []struct {
+		Name string `json:"name"`
+	} `json:"artists"`
+	Album struct {
+		Name string `json:"name"`
+	} `json:"album"`
+	DurationMs int `json:"duration_ms"`
+	ExternalURLs struct {
+		Spotify string `json:"spotify"`
+	} `json:"external_urls"`
+}
+
+// SpotifyPlaylist represents a playlist from Spotify API
+type SpotifyPlaylist struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Tracks struct {
+		Total int `json:"total"`
+	} `json:"tracks"`
+}
+
+// FetchLikedSongs fetches the user's liked songs from Spotify
+func (m *Manager) FetchLikedSongs(ctx context.Context, limit, offset int) ([]SpotifyTrack, int, error) {
+	token, err := m.getValidToken(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	url := fmt.Sprintf("%s/me/tracks?limit=%d&offset=%d", SpotifyAPIURL, limit, offset)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, 0, fmt.Errorf("spotify API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Items []struct {
+			Track SpotifyTrack `json:"track"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, 0, err
+	}
+
+	tracks := make([]SpotifyTrack, len(result.Items))
+	for i, item := range result.Items {
+		tracks[i] = item.Track
+	}
+
+	return tracks, result.Total, nil
+}
+
+// FetchUserPlaylists fetches the user's playlists from Spotify
+func (m *Manager) FetchUserPlaylists(ctx context.Context) ([]SpotifyPlaylist, error) {
+	token, err := m.getValidToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var allPlaylists []SpotifyPlaylist
+	offset := 0
+	limit := 50
+
+	for {
+		url := fmt.Sprintf("%s/me/playlists?limit=%d&offset=%d", SpotifyAPIURL, limit, offset)
+		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		client := &http.Client{Timeout: 30 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("spotify API error %d: %s", resp.StatusCode, string(body))
+		}
+
+		var result struct {
+			Items []SpotifyPlaylist `json:"items"`
+			Total int               `json:"total"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			resp.Body.Close()
+			return nil, err
+		}
+		resp.Body.Close()
+
+		allPlaylists = append(allPlaylists, result.Items...)
+
+		if len(allPlaylists) >= result.Total {
+			break
+		}
+		offset += limit
+	}
+
+	return allPlaylists, nil
+}
+
+// FetchPlaylistTracks fetches tracks from a specific playlist
+func (m *Manager) FetchPlaylistTracks(ctx context.Context, playlistID string, limit, offset int) ([]SpotifyTrack, int, error) {
+	token, err := m.getValidToken(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	url := fmt.Sprintf("%s/playlists/%s/tracks?limit=%d&offset=%d", SpotifyAPIURL, playlistID, limit, offset)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, 0, fmt.Errorf("spotify API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Items []struct {
+			Track SpotifyTrack `json:"track"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, 0, err
+	}
+
+	tracks := make([]SpotifyTrack, 0, len(result.Items))
+	for _, item := range result.Items {
+		// Skip nil tracks (can happen with local files)
+		if item.Track.ID != "" {
+			tracks = append(tracks, item.Track)
+		}
+	}
+
+	return tracks, result.Total, nil
+}
+
+func (m *Manager) SyncLikes(ctx context.Context) error {
+	if !m.syncMutex.TryLock() {
+		fmt.Println("[Spotify] Sync already in progress, skipping")
+		return nil
+	}
+	defer m.syncMutex.Unlock()
+
+	fmt.Println("[Spotify] Starting sync...")
+	started := time.Now()
+
+	cfg, err := m.repo.GetSyncConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get sync config: %w", err)
+	}
+
+	if cfg == nil {
+		fmt.Println("[Spotify] Sync not configured, skipping")
+		return nil
+	}
+
+	if !cfg.Enabled {
+		fmt.Println("[Spotify] Sync disabled, skipping")
+		return nil
+	}
+
+	if cfg.AccessToken == nil || *cfg.AccessToken == "" {
+		return fmt.Errorf("access token not configured")
+	}
+
+	playlistID, err := m.ensureLikedSongsPlaylist(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to ensure playlist: %w", err)
+	}
+
+	tracksAdded := 0
+	tracksSkipped := 0
+	var trackIDs []string
+
+	// Fetch liked songs with pagination
+	offset := 0
+	limit := 50
+	for {
+		spotifyTracks, total, err := m.FetchLikedSongs(ctx, limit, offset)
+		if err != nil {
+			errMsg := fmt.Sprintf("failed to fetch liked songs: %v", err)
+			m.repo.RecordSync(ctx, started, tracksAdded, tracksSkipped, &errMsg)
+			return fmt.Errorf(errMsg)
+		}
+
+		for _, st := range spotifyTracks {
+			synced, err := m.repo.IsSpotifyTrackSynced(ctx, st.ID)
+			if err != nil {
+				fmt.Printf("[Spotify] Error checking if track synced: %v\n", err)
+			}
+			if synced {
+				fmt.Printf("[Spotify] Skipping already synced track: %s\n", st.Name)
+				tracksSkipped++
+				continue
+			}
+
+			trackID, err := m.downloadAndImportTrack(ctx, cfg.OwnerUserID, st)
+			if err != nil {
+				fmt.Printf("[Spotify] Skipping track %s: %v\n", st.Name, err)
+				tracksSkipped++
+				continue
+			}
+
+			if err := m.repo.RecordSyncedTrack(ctx, st.ID, trackID); err != nil {
+				fmt.Printf("[Spotify] Warning: failed to record synced track: %v\n", err)
+			}
+
+			trackIDs = append(trackIDs, trackID)
+			tracksAdded++
+			fmt.Printf("[Spotify] Imported: %s - %s\n", getArtistName(st), st.Name)
+		}
+
+		offset += limit
+		if offset >= total {
+			break
+		}
+	}
+
+	if len(trackIDs) > 0 {
+		req := &imodels.AddTracksToPlaylistRequest{TrackIDs: trackIDs}
+		if err := m.playlistsManager.AddTracksToPlaylist(playlistID, cfg.OwnerUserID, req); err != nil {
+			fmt.Printf("[Spotify] Warning: failed to add tracks to playlist: %v\n", err)
+		}
+	}
+
+	m.repo.UpdateLastSync(ctx)
+	m.repo.RecordSync(ctx, started, tracksAdded, tracksSkipped, nil)
+
+	fmt.Printf("[Spotify] Sync complete: %d added, %d skipped\n", tracksAdded, tracksSkipped)
+	return nil
+}
+
+func (m *Manager) ensureLikedSongsPlaylist(ctx context.Context, cfg *SyncConfig) (string, error) {
+	if cfg.LikedSongsPlaylistID != nil && *cfg.LikedSongsPlaylistID != "" {
+		return *cfg.LikedSongsPlaylistID, nil
+	}
+
+	desc := "Auto-synced from Spotify liked songs"
+	isPublic := false
+	req := &imodels.CreatePlaylistRequest{
+		Name:        "Spotify Liked Songs",
+		Description: &desc,
+		IsPublic:    &isPublic,
+	}
+
+	playlist, err := m.playlistsManager.CreatePlaylist(cfg.OwnerUserID, req)
+	if err != nil {
+		return "", err
+	}
+
+	if err := m.repo.UpdateLikedSongsPlaylistID(ctx, playlist.ID); err != nil {
+		fmt.Printf("[Spotify] Warning: failed to update playlist ID in config: %v\n", err)
+	}
+
+	fmt.Printf("[Spotify] Created playlist: %s (%s)\n", playlist.Name, playlist.ID)
+	return playlist.ID, nil
+}
+
+func (m *Manager) downloadAndImportTrack(ctx context.Context, userID string, st SpotifyTrack) (string, error) {
+	tmpDir := filepath.Join(m.dataDir, "tmp", fmt.Sprintf("spotify-%s", st.ID))
+	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Use yt-dlp to download from Spotify (requires spotify-dl or similar setup)
+	// Fall back to searching YouTube for the track
+	searchQuery := fmt.Sprintf("%s %s", getArtistName(st), st.Name)
+	outputTemplate := filepath.Join(tmpDir, "%(title)s.%(ext)s")
+
+	cmd := exec.CommandContext(ctx, "yt-dlp",
+		"--default-search", "ytsearch1",
+		"-x", "--audio-format", "mp3",
+		"--audio-quality", "0",
+		"-o", outputTemplate,
+		searchQuery,
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("download failed: %v, output: %s", err, string(output))
+	}
+
+	files, err := os.ReadDir(tmpDir)
+	if err != nil || len(files) == 0 {
+		return "", fmt.Errorf("no files downloaded")
+	}
+
+	downloadedFile := filepath.Join(tmpDir, files[0].Name())
+
+	file, err := os.Open(downloadedFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to open downloaded file: %w", err)
+	}
+	defer file.Close()
+
+	filename := files[0].Name()
+	trackID := utils.GenerateTrackID()
+
+	relPath, size, contentType, err := m.storage.Save(ctx, userID, trackID, filename, file)
+	if err != nil {
+		return "", fmt.Errorf("failed to save file: %w", err)
+	}
+
+	fullPath, _ := m.storage.ResolveFullPath(relPath)
+	md, err := m.extractor.Extract(ctx, fullPath)
+	if err != nil {
+		fmt.Printf("[Spotify] Warning: metadata extraction failed for %s: %v\n", filename, err)
+		md = &metadata.AudioMetadata{}
+	}
+
+	track := &imodels.Track{
+		OwnerUserID:      userID,
+		OriginalFilename: filename,
+		ContentType:      contentType,
+		SizeBytes:        size,
+		FilePath:         relPath,
+		CreatedAt:        utils.Now(),
+		UpdatedAt:        utils.Now(),
+	}
+
+	// Prefer Spotify metadata over extracted metadata
+	title := st.Name
+	track.Title = &title
+
+	artist := getArtistName(st)
+	if artist != "" {
+		track.Artist = &artist
+	} else if md.Artist != nil {
+		track.Artist = md.Artist
+	}
+
+	album := st.Album.Name
+	if album != "" {
+		track.Album = &album
+	} else if md.Album != nil {
+		track.Album = md.Album
+	}
+
+	duration := float64(st.DurationMs) / 1000
+	if duration > 0 {
+		track.DurationSeconds = &duration
+	} else if md.DurationSeconds > 0 {
+		track.DurationSeconds = &md.DurationSeconds
+	}
+
+	if md.SampleRate != nil {
+		track.SampleRate = md.SampleRate
+	}
+	if md.Bitrate != nil {
+		track.Bitrate = md.Bitrate
+	}
+
+	track, err = m.tracksRepo.CreateTrack(ctx, track)
+	if err != nil {
+		m.storage.Delete(ctx, relPath)
+		return "", fmt.Errorf("failed to create track record: %w", err)
+	}
+
+	return track.ID, nil
+}
+
+func getArtistName(st SpotifyTrack) string {
+	if len(st.Artists) > 0 {
+		names := make([]string, len(st.Artists))
+		for i, a := range st.Artists {
+			names[i] = a.Name
+		}
+		return strings.Join(names, ", ")
+	}
+	return ""
+}
+
+// GetSyncedPlaylists returns all synced Spotify playlists
+func (m *Manager) GetSyncedPlaylists(ctx context.Context) ([]*SyncedPlaylist, error) {
+	return m.repo.GetSyncedPlaylists(ctx)
+}
+
+// Disconnect removes the Spotify connection
+func (m *Manager) Disconnect(ctx context.Context) error {
+	cfg, err := m.repo.GetSyncConfig(ctx)
+	if err != nil || cfg == nil {
+		return nil
+	}
+
+	cfg.AccessToken = nil
+	cfg.RefreshToken = nil
+	cfg.TokenExpiresAt = nil
+	cfg.Enabled = false
+
+	return m.repo.UpsertSyncConfig(ctx, cfg)
+}

--- a/backend/spotify/repository.go
+++ b/backend/spotify/repository.go
@@ -1,0 +1,268 @@
+package spotify
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/faraz525/home-music-server/backend/internal/db"
+	"github.com/faraz525/home-music-server/backend/utils"
+)
+
+type Repository struct {
+	db *db.DB
+}
+
+func NewRepository(db *db.DB) *Repository {
+	return &Repository{db: db}
+}
+
+type SyncConfig struct {
+	ID                   int        `json:"id"`
+	AccessToken          *string    `json:"access_token,omitempty"`
+	RefreshToken         *string    `json:"refresh_token,omitempty"`
+	TokenExpiresAt       *time.Time `json:"token_expires_at,omitempty"`
+	OwnerUserID          string     `json:"owner_user_id"`
+	LikedSongsPlaylistID *string    `json:"liked_songs_playlist_id"`
+	Enabled              bool       `json:"enabled"`
+	LastSyncAt           *time.Time `json:"last_sync_at"`
+	CreatedAt            time.Time  `json:"created_at"`
+	UpdatedAt            time.Time  `json:"updated_at"`
+}
+
+func (r *Repository) GetSyncConfig(ctx context.Context) (*SyncConfig, error) {
+	var cfg SyncConfig
+	var accessToken, refreshToken, playlistID sql.NullString
+	var tokenExpiresAt, lastSyncAt sql.NullTime
+
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id, access_token, refresh_token, token_expires_at, owner_user_id, 
+                liked_songs_playlist_id, enabled, last_sync_at, created_at, updated_at
+         FROM spotify_sync_config WHERE id = 1`,
+	).Scan(&cfg.ID, &accessToken, &refreshToken, &tokenExpiresAt, &cfg.OwnerUserID,
+		&playlistID, &cfg.Enabled, &lastSyncAt, &cfg.CreatedAt, &cfg.UpdatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if accessToken.Valid {
+		cfg.AccessToken = &accessToken.String
+	}
+	if refreshToken.Valid {
+		cfg.RefreshToken = &refreshToken.String
+	}
+	if tokenExpiresAt.Valid {
+		cfg.TokenExpiresAt = &tokenExpiresAt.Time
+	}
+	if playlistID.Valid {
+		cfg.LikedSongsPlaylistID = &playlistID.String
+	}
+	if lastSyncAt.Valid {
+		cfg.LastSyncAt = &lastSyncAt.Time
+	}
+
+	return &cfg, nil
+}
+
+func (r *Repository) UpsertSyncConfig(ctx context.Context, cfg *SyncConfig) error {
+	now := time.Now()
+
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO spotify_sync_config (id, access_token, refresh_token, token_expires_at, owner_user_id, 
+                                          liked_songs_playlist_id, enabled, created_at, updated_at)
+         VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+            access_token = excluded.access_token,
+            refresh_token = excluded.refresh_token,
+            token_expires_at = excluded.token_expires_at,
+            owner_user_id = excluded.owner_user_id,
+            liked_songs_playlist_id = excluded.liked_songs_playlist_id,
+            enabled = excluded.enabled,
+            updated_at = excluded.updated_at`,
+		cfg.AccessToken, cfg.RefreshToken, cfg.TokenExpiresAt, cfg.OwnerUserID,
+		cfg.LikedSongsPlaylistID, cfg.Enabled, now, now,
+	)
+	return err
+}
+
+func (r *Repository) UpdateTokens(ctx context.Context, accessToken, refreshToken string, expiresAt time.Time) error {
+	now := time.Now()
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE spotify_sync_config SET access_token = ?, refresh_token = ?, token_expires_at = ?, updated_at = ? WHERE id = 1`,
+		accessToken, refreshToken, expiresAt, now,
+	)
+	return err
+}
+
+func (r *Repository) UpdateLastSync(ctx context.Context) error {
+	now := time.Now()
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE spotify_sync_config SET last_sync_at = ?, updated_at = ? WHERE id = 1`,
+		now, now,
+	)
+	return err
+}
+
+func (r *Repository) UpdateLikedSongsPlaylistID(ctx context.Context, playlistID string) error {
+	now := time.Now()
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE spotify_sync_config SET liked_songs_playlist_id = ?, updated_at = ? WHERE id = 1`,
+		playlistID, now,
+	)
+	return err
+}
+
+func (r *Repository) RecordSync(ctx context.Context, started time.Time, tracksAdded, tracksSkipped int, errMsg *string) error {
+	id := utils.GenerateID("sync")
+	now := time.Now()
+
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO spotify_sync_history (id, sync_started_at, sync_completed_at, tracks_added, tracks_skipped, error_message)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+		id, started, now, tracksAdded, tracksSkipped, errMsg,
+	)
+	return err
+}
+
+func (r *Repository) GetSyncHistory(ctx context.Context, limit int) ([]*SyncHistory, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, sync_started_at, sync_completed_at, tracks_added, tracks_skipped, error_message
+         FROM spotify_sync_history ORDER BY sync_started_at DESC LIMIT ?`,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var history []*SyncHistory
+	for rows.Next() {
+		var h SyncHistory
+		var completedAt sql.NullTime
+		var errMsg sql.NullString
+
+		err := rows.Scan(&h.ID, &h.StartedAt, &completedAt, &h.TracksAdded, &h.TracksSkipped, &errMsg)
+		if err != nil {
+			return nil, err
+		}
+
+		if completedAt.Valid {
+			h.CompletedAt = &completedAt.Time
+		}
+		if errMsg.Valid {
+			h.ErrorMessage = &errMsg.String
+		}
+
+		history = append(history, &h)
+	}
+
+	return history, rows.Err()
+}
+
+type SyncHistory struct {
+	ID            string     `json:"id"`
+	StartedAt     time.Time  `json:"started_at"`
+	CompletedAt   *time.Time `json:"completed_at,omitempty"`
+	TracksAdded   int        `json:"tracks_added"`
+	TracksSkipped int        `json:"tracks_skipped"`
+	ErrorMessage  *string    `json:"error_message,omitempty"`
+}
+
+func (r *Repository) IsSpotifyTrackSynced(ctx context.Context, spotifyID string) (bool, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM spotify_synced_tracks WHERE spotify_id = ?`,
+		spotifyID,
+	).Scan(&count)
+	return count > 0, err
+}
+
+func (r *Repository) RecordSyncedTrack(ctx context.Context, spotifyID, trackID string) error {
+	id := utils.GenerateID("spt")
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO spotify_synced_tracks (id, spotify_id, track_id, synced_at)
+         VALUES (?, ?, ?, ?)`,
+		id, spotifyID, trackID, time.Now(),
+	)
+	return err
+}
+
+// Synced playlist management
+type SyncedPlaylist struct {
+	ID                string     `json:"id"`
+	SpotifyPlaylistID string     `json:"spotify_playlist_id"`
+	LocalPlaylistID   string     `json:"local_playlist_id"`
+	Name              string     `json:"name"`
+	Enabled           bool       `json:"enabled"`
+	LastSyncAt        *time.Time `json:"last_sync_at,omitempty"`
+	CreatedAt         time.Time  `json:"created_at"`
+}
+
+func (r *Repository) GetSyncedPlaylists(ctx context.Context) ([]*SyncedPlaylist, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, spotify_playlist_id, local_playlist_id, name, enabled, last_sync_at, created_at
+         FROM spotify_synced_playlists ORDER BY name ASC`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var playlists []*SyncedPlaylist
+	for rows.Next() {
+		var p SyncedPlaylist
+		var lastSyncAt sql.NullTime
+
+		err := rows.Scan(&p.ID, &p.SpotifyPlaylistID, &p.LocalPlaylistID, &p.Name, &p.Enabled, &lastSyncAt, &p.CreatedAt)
+		if err != nil {
+			return nil, err
+		}
+
+		if lastSyncAt.Valid {
+			p.LastSyncAt = &lastSyncAt.Time
+		}
+
+		playlists = append(playlists, &p)
+	}
+
+	return playlists, rows.Err()
+}
+
+func (r *Repository) AddSyncedPlaylist(ctx context.Context, spotifyID, localID, name string) error {
+	id := utils.GenerateID("spp")
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO spotify_synced_playlists (id, spotify_playlist_id, local_playlist_id, name, enabled, created_at)
+         VALUES (?, ?, ?, ?, TRUE, ?)
+         ON CONFLICT(spotify_playlist_id) DO UPDATE SET name = excluded.name`,
+		id, spotifyID, localID, name, time.Now(),
+	)
+	return err
+}
+
+func (r *Repository) UpdateSyncedPlaylistLastSync(ctx context.Context, spotifyID string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE spotify_synced_playlists SET last_sync_at = ? WHERE spotify_playlist_id = ?`,
+		time.Now(), spotifyID,
+	)
+	return err
+}
+
+func (r *Repository) SetSyncedPlaylistEnabled(ctx context.Context, spotifyID string, enabled bool) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE spotify_synced_playlists SET enabled = ? WHERE spotify_playlist_id = ?`,
+		enabled, spotifyID,
+	)
+	return err
+}
+
+func (r *Repository) DeleteSyncedPlaylist(ctx context.Context, spotifyID string) error {
+	_, err := r.db.ExecContext(ctx,
+		`DELETE FROM spotify_synced_playlists WHERE spotify_playlist_id = ?`,
+		spotifyID,
+	)
+	return err
+}

--- a/backend/spotify/routes.go
+++ b/backend/spotify/routes.go
@@ -1,0 +1,23 @@
+package spotify
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func Routes(manager *Manager) func(*gin.RouterGroup) {
+	return func(rg *gin.RouterGroup) {
+		handlers := NewHandlers(manager)
+
+		sp := rg.Group("/spotify")
+		{
+			sp.GET("/config", handlers.GetConfig)
+			sp.PUT("/config", handlers.UpdateConfig)
+			sp.POST("/token", handlers.ExchangeToken)
+			sp.POST("/disconnect", handlers.Disconnect)
+			sp.POST("/sync", handlers.TriggerSync)
+			sp.GET("/history", handlers.GetHistory)
+			sp.GET("/playlists", handlers.GetPlaylists)
+			sp.GET("/synced-playlists", handlers.GetSyncedPlaylists)
+		}
+	}
+}

--- a/backend/spotify/ticker.go
+++ b/backend/spotify/ticker.go
@@ -1,0 +1,39 @@
+package spotify
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func StartSyncLoop(ctx context.Context, manager *Manager) {
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+
+	fmt.Println("[Spotify] Sync loop started (24h interval)")
+
+	initialDelay := time.NewTimer(2 * time.Minute)
+	defer initialDelay.Stop()
+
+	select {
+	case <-ctx.Done():
+		fmt.Println("[Spotify] Sync loop cancelled before initial run")
+		return
+	case <-initialDelay.C:
+		if err := manager.SyncLikes(ctx); err != nil {
+			fmt.Printf("[Spotify] Initial sync failed: %v\n", err)
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("[Spotify] Sync loop stopped")
+			return
+		case <-ticker.C:
+			if err := manager.SyncLikes(ctx); err != nil {
+				fmt.Printf("[Spotify] Scheduled sync failed: %v\n", err)
+			}
+		}
+	}
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { CommunityPage } from './pages/CommunityPage'
 import { UploadPage } from './pages/UploadPage'
 import { AdminPage } from './pages/AdminPage'
 import { SoundCloudPage } from './pages/SoundCloudPage'
+import { SpotifyPage } from './pages/SpotifyPage'
 import { NotFound } from './pages/NotFound'
 import { AuthProvider, useAuth } from './state/auth'
 
@@ -37,6 +38,7 @@ export default function App() {
           <Route path="/community" element={<CommunityPage />} />
           <Route path="/admin" element={<AdminPage />} />
           <Route path="/soundcloud" element={<SoundCloudPage />} />
+          <Route path="/spotify" element={<SpotifyPage />} />
         </Route>
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,5 +1,5 @@
 import { NavLink, Outlet, Link, useLocation } from 'react-router-dom'
-import { Library, LogOut, Settings, UploadCloud, Folder, Menu, X, FolderOpen, Globe, Disc, Cloud } from 'lucide-react'
+import { Library, LogOut, Settings, UploadCloud, Folder, Menu, X, FolderOpen, Globe, Disc, Cloud, Music2 } from 'lucide-react'
 import { useAuth } from '../../state/auth'
 import { PlayerBar } from '../player/PlayerBar'
 import { useCallback, useEffect, useState } from 'react'
@@ -103,6 +103,7 @@ export function Layout() {
             <>
               <NavItem to="/admin" label="Admin" icon={<Settings size={18} />} />
               <NavItem to="/soundcloud" label="SoundCloud" icon={<Cloud size={18} />} />
+              <NavItem to="/spotify" label="Spotify" icon={<Music2 size={18} />} />
             </>
           )}
 
@@ -187,6 +188,7 @@ export function Layout() {
               <>
                 <NavItem to="/admin" label="Admin" icon={<Settings size={18} />} />
                 <NavItem to="/soundcloud" label="SoundCloud" icon={<Cloud size={18} />} />
+                <NavItem to="/spotify" label="Spotify" icon={<Music2 size={18} />} />
               </>
             )}
 
@@ -292,6 +294,7 @@ function SidebarContent({ user, logout, onNavigate, crates, selectedCrateId }: {
           <>
             <NavItem to="/admin" label="Admin" icon={<Settings size={18} />} onClick={onNavigate} />
             <NavItem to="/soundcloud" label="SoundCloud" icon={<Cloud size={18} />} onClick={onNavigate} />
+            <NavItem to="/spotify" label="Spotify" icon={<Music2 size={18} />} onClick={onNavigate} />
           </>
         )}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -155,3 +155,48 @@ export const soundcloudApi = {
   getHistory: () =>
     api.get<{ history: SoundCloudSyncHistory[] }>('/api/soundcloud/history'),
 }
+
+// Spotify sync API
+export type SpotifyConfig = {
+  configured: boolean
+  enabled: boolean
+  owner_user_id?: string
+  liked_songs_playlist_id?: string
+  last_sync_at?: string
+  client_id?: string
+}
+
+export type SpotifySyncHistory = {
+  id: string
+  started_at: string
+  completed_at?: string
+  tracks_added: number
+  tracks_skipped: number
+  error_message?: string
+}
+
+export const spotifyApi = {
+  getConfig: () =>
+    api.get<SpotifyConfig>('/api/spotify/config'),
+
+  updateConfig: (data: { enabled: boolean }) =>
+    api.put('/api/spotify/config', data),
+
+  exchangeToken: (data: { code: string; code_verifier: string; redirect_uri: string }) =>
+    api.post('/api/spotify/token', data),
+
+  disconnect: () =>
+    api.post('/api/spotify/disconnect'),
+
+  triggerSync: () =>
+    api.post('/api/spotify/sync'),
+
+  getHistory: () =>
+    api.get<{ history: SpotifySyncHistory[] }>('/api/spotify/history'),
+
+  getPlaylists: () =>
+    api.get<{ playlists: Array<{ id: string; name: string; tracks: { total: number } }> }>('/api/spotify/playlists'),
+
+  getSyncedPlaylists: () =>
+    api.get<{ playlists: Array<{ id: string; spotify_playlist_id: string; local_playlist_id: string; name: string; enabled: boolean }> }>('/api/spotify/synced-playlists'),
+}

--- a/frontend/src/pages/SpotifyPage.tsx
+++ b/frontend/src/pages/SpotifyPage.tsx
@@ -5,7 +5,6 @@ import { useAuth } from '../state/auth'
 import { toast } from 'sonner'
 import { useSearchParams } from 'react-router-dom'
 
-// PKCE helpers
 function generateRandomString(length: number): string {
   const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
   const values = crypto.getRandomValues(new Uint8Array(length))
@@ -61,7 +60,6 @@ export function SpotifyPage() {
     }
   }, [])
 
-  // Handle OAuth callback
   useEffect(() => {
     const code = searchParams.get('code')
     const state = searchParams.get('state')
@@ -83,7 +81,6 @@ export function SpotifyPage() {
       } else if (!codeVerifier) {
         toast.error('Code verifier not found. Please try connecting again.')
       } else {
-        // Exchange code for token
         setConnecting(true)
         spotifyApi.exchangeToken({
           code,
@@ -104,7 +101,6 @@ export function SpotifyPage() {
           })
       }
 
-      // Clean up URL
       searchParams.delete('code')
       searchParams.delete('state')
       setSearchParams(searchParams)
@@ -125,7 +121,6 @@ export function SpotifyPage() {
     const state = generateRandomString(16)
     const codeChallenge = await generateCodeChallenge(codeVerifier)
 
-    // Store for later verification
     sessionStorage.setItem('spotify_code_verifier', codeVerifier)
     sessionStorage.setItem('spotify_auth_state', state)
 

--- a/frontend/src/pages/SpotifyPage.tsx
+++ b/frontend/src/pages/SpotifyPage.tsx
@@ -1,0 +1,420 @@
+import { useEffect, useState, useCallback } from 'react'
+import { Music2, RefreshCw, Check, X, Disc, History, AlertCircle, Link2, Unlink } from 'lucide-react'
+import { spotifyApi, SpotifyConfig, SpotifySyncHistory } from '../lib/api'
+import { useAuth } from '../state/auth'
+import { toast } from 'sonner'
+import { useSearchParams } from 'react-router-dom'
+
+// PKCE helpers
+function generateRandomString(length: number): string {
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  const values = crypto.getRandomValues(new Uint8Array(length))
+  return values.reduce((acc, x) => acc + possible[x % possible.length], '')
+}
+
+async function sha256(plain: string): Promise<ArrayBuffer> {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(plain)
+  return window.crypto.subtle.digest('SHA-256', data)
+}
+
+function base64encode(input: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(input)))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+}
+
+async function generateCodeChallenge(codeVerifier: string): Promise<string> {
+  const hashed = await sha256(codeVerifier)
+  return base64encode(hashed)
+}
+
+const SPOTIFY_AUTH_URL = 'https://accounts.spotify.com/authorize'
+const SPOTIFY_SCOPES = ['user-library-read', 'playlist-read-private', 'playlist-read-collaborative']
+
+export function SpotifyPage() {
+  const { user } = useAuth()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [config, setConfig] = useState<SpotifyConfig | null>(null)
+  const [history, setHistory] = useState<SpotifySyncHistory[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [syncing, setSyncing] = useState(false)
+  const [connecting, setConnecting] = useState(false)
+  const [enabled, setEnabled] = useState(false)
+
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [configRes, historyRes] = await Promise.all([
+        spotifyApi.getConfig(),
+        spotifyApi.getHistory(),
+      ])
+      setConfig(configRes.data)
+      setHistory(historyRes.data?.history || [])
+      setEnabled(configRes.data?.enabled || false)
+    } catch {
+      toast.error('Failed to load Spotify configuration')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Handle OAuth callback
+  useEffect(() => {
+    const code = searchParams.get('code')
+    const state = searchParams.get('state')
+    const error = searchParams.get('error')
+
+    if (error) {
+      toast.error(`Spotify authorization failed: ${error}`)
+      searchParams.delete('error')
+      setSearchParams(searchParams)
+      return
+    }
+
+    if (code && state) {
+      const storedState = sessionStorage.getItem('spotify_auth_state')
+      const codeVerifier = sessionStorage.getItem('spotify_code_verifier')
+
+      if (state !== storedState) {
+        toast.error('State mismatch. Please try connecting again.')
+      } else if (!codeVerifier) {
+        toast.error('Code verifier not found. Please try connecting again.')
+      } else {
+        // Exchange code for token
+        setConnecting(true)
+        spotifyApi.exchangeToken({
+          code,
+          code_verifier: codeVerifier,
+          redirect_uri: window.location.origin + '/spotify',
+        })
+          .then(() => {
+            toast.success('Connected to Spotify!')
+            sessionStorage.removeItem('spotify_auth_state')
+            sessionStorage.removeItem('spotify_code_verifier')
+            fetchData()
+          })
+          .catch(() => {
+            toast.error('Failed to connect to Spotify')
+          })
+          .finally(() => {
+            setConnecting(false)
+          })
+      }
+
+      // Clean up URL
+      searchParams.delete('code')
+      searchParams.delete('state')
+      setSearchParams(searchParams)
+    }
+  }, [searchParams, setSearchParams, fetchData])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  async function handleConnect() {
+    if (!config?.client_id) {
+      toast.error('Spotify client ID not configured on server')
+      return
+    }
+
+    const codeVerifier = generateRandomString(64)
+    const state = generateRandomString(16)
+    const codeChallenge = await generateCodeChallenge(codeVerifier)
+
+    // Store for later verification
+    sessionStorage.setItem('spotify_code_verifier', codeVerifier)
+    sessionStorage.setItem('spotify_auth_state', state)
+
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: config.client_id,
+      scope: SPOTIFY_SCOPES.join(' '),
+      redirect_uri: window.location.origin + '/spotify',
+      state: state,
+      code_challenge_method: 'S256',
+      code_challenge: codeChallenge,
+    })
+
+    window.location.href = `${SPOTIFY_AUTH_URL}?${params.toString()}`
+  }
+
+  async function handleDisconnect() {
+    try {
+      await spotifyApi.disconnect()
+      toast.success('Disconnected from Spotify')
+      fetchData()
+    } catch {
+      toast.error('Failed to disconnect')
+    }
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    try {
+      await spotifyApi.updateConfig({ enabled })
+      toast.success('Spotify configuration saved')
+      fetchData()
+    } catch {
+      toast.error('Failed to save configuration')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleSync() {
+    setSyncing(true)
+    try {
+      await spotifyApi.triggerSync()
+      toast.success('Sync started! Check back in a few minutes.')
+      setTimeout(fetchData, 5000)
+    } catch {
+      toast.error('Failed to trigger sync')
+    } finally {
+      setSyncing(false)
+    }
+  }
+
+  function formatDate(dateString?: string) {
+    if (!dateString) return 'Never'
+    return new Date(dateString).toLocaleString()
+  }
+
+  if (user?.role !== 'admin') {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-display font-bold text-crate-cream">Spotify Sync</h1>
+          <p className="text-crate-muted mt-1">Admin access required</p>
+        </div>
+        <div className="card p-8 text-center">
+          <AlertCircle size={48} className="mx-auto text-crate-subtle mb-4" />
+          <p className="text-crate-muted">Only admins can configure Spotify sync.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-display font-bold text-crate-cream">Spotify Sync</h1>
+        <p className="text-crate-muted mt-1">Auto-sync your Spotify liked songs to CrateDrop</p>
+      </div>
+
+      {loading || connecting ? (
+        <div className="flex items-center justify-center gap-3 py-12">
+          <Disc className="text-crate-amber vinyl-spinning" size={24} />
+          <span className="text-crate-muted">{connecting ? 'Connecting to Spotify...' : 'Loading...'}</span>
+        </div>
+      ) : (
+        <>
+          {/* Status Card */}
+          <div className="card p-5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-4">
+                <div className="p-3 rounded-xl bg-green-500/10">
+                  <Music2 size={24} className="text-green-500" />
+                </div>
+                <div>
+                  <div className="text-sm text-crate-muted">Status</div>
+                  <div className="flex items-center gap-2">
+                    {config?.configured ? (
+                      <>
+                        {config?.enabled ? (
+                          <span className="flex items-center gap-1.5 text-green-500">
+                            <Check size={16} /> Active (auto-sync on)
+                          </span>
+                        ) : (
+                          <span className="flex items-center gap-1.5 text-crate-amber">
+                            <Check size={16} /> Connected (auto-sync off)
+                          </span>
+                        )}
+                      </>
+                    ) : (
+                      <span className="text-crate-muted">Not connected</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                {config?.configured && (
+                  <>
+                    <button
+                      onClick={handleDisconnect}
+                      className="btn-ghost flex items-center gap-2 text-crate-muted hover:text-red-500"
+                    >
+                      <Unlink size={16} />
+                      Disconnect
+                    </button>
+                    <button
+                      onClick={handleSync}
+                      disabled={syncing}
+                      className="btn-secondary flex items-center gap-2"
+                    >
+                      <RefreshCw size={16} className={syncing ? 'animate-spin' : ''} />
+                      {syncing ? 'Syncing...' : 'Sync Now'}
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+            {config?.last_sync_at && (
+              <div className="mt-4 pt-4 border-t border-crate-border">
+                <span className="text-sm text-crate-muted">
+                  Last sync: {formatDate(config.last_sync_at)}
+                </span>
+              </div>
+            )}
+          </div>
+
+          {/* Connect or Configuration Card */}
+          <div className="card overflow-hidden">
+            <div className="p-5 border-b border-crate-border">
+              <h2 className="text-lg font-display font-semibold text-crate-cream">
+                {config?.configured ? 'Configuration' : 'Connect to Spotify'}
+              </h2>
+            </div>
+            <div className="p-5 space-y-4">
+              {!config?.configured ? (
+                <div className="text-center py-6">
+                  <Music2 size={48} className="mx-auto text-green-500 mb-4" />
+                  <p className="text-crate-muted mb-6">
+                    Connect your Spotify account to sync your liked songs automatically.
+                  </p>
+                  {!config?.client_id ? (
+                    <div className="p-4 bg-crate-amber/10 border border-crate-amber/20 rounded-xl text-sm text-crate-amber">
+                      <AlertCircle size={16} className="inline mr-2" />
+                      SPOTIFY_CLIENT_ID environment variable not set on server
+                    </div>
+                  ) : (
+                    <button
+                      onClick={handleConnect}
+                      className="btn-primary bg-green-600 hover:bg-green-700 flex items-center gap-2 mx-auto"
+                    >
+                      <Link2 size={16} />
+                      Connect with Spotify
+                    </button>
+                  )}
+                </div>
+              ) : (
+                <>
+                  <div className="flex items-center gap-3">
+                    <button
+                      onClick={() => setEnabled(!enabled)}
+                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                        enabled ? 'bg-green-500' : 'bg-crate-elevated'
+                      }`}
+                    >
+                      <span
+                        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                          enabled ? 'translate-x-6' : 'translate-x-1'
+                        }`}
+                      />
+                    </button>
+                    <span className="text-sm text-crate-cream">
+                      Enable automatic daily sync
+                    </span>
+                  </div>
+
+                  <div className="pt-4">
+                    <button
+                      onClick={handleSave}
+                      disabled={saving}
+                      className="btn-primary"
+                    >
+                      {saving ? 'Saving...' : 'Save Configuration'}
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Sync History */}
+          {config?.configured && (
+            <div className="card overflow-hidden">
+              <div className="p-5 border-b border-crate-border flex items-center gap-2">
+                <History size={18} className="text-crate-muted" />
+                <h2 className="text-lg font-display font-semibold text-crate-cream">Sync History</h2>
+              </div>
+
+              {history.length === 0 ? (
+                <div className="text-center py-12">
+                  <History size={32} className="mx-auto text-crate-subtle mb-3" />
+                  <p className="text-crate-muted">No sync history yet</p>
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="border-b border-crate-border bg-crate-elevated/50">
+                        <th className="text-left py-3 px-5 text-xs uppercase tracking-wider text-crate-subtle font-medium">
+                          Date
+                        </th>
+                        <th className="text-right py-3 px-5 text-xs uppercase tracking-wider text-crate-subtle font-medium">
+                          Added
+                        </th>
+                        <th className="text-right py-3 px-5 text-xs uppercase tracking-wider text-crate-subtle font-medium">
+                          Skipped
+                        </th>
+                        <th className="text-left py-3 px-5 text-xs uppercase tracking-wider text-crate-subtle font-medium">
+                          Status
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-crate-border/50">
+                      {history.map((h, idx) => (
+                        <tr
+                          key={h.id}
+                          className="stagger-item hover:bg-crate-elevated/30 transition-colors"
+                          style={{ animationDelay: `${idx * 30}ms` }}
+                        >
+                          <td className="py-4 px-5 text-crate-cream">
+                            {formatDate(h.started_at)}
+                          </td>
+                          <td className="py-4 px-5 text-right text-green-500 tabular-nums">
+                            +{h.tracks_added}
+                          </td>
+                          <td className="py-4 px-5 text-right text-crate-muted tabular-nums">
+                            {h.tracks_skipped}
+                          </td>
+                          <td className="py-4 px-5">
+                            {h.error_message ? (
+                              <span className="text-red-500 text-sm" title={h.error_message}>
+                                Failed
+                              </span>
+                            ) : h.completed_at ? (
+                              <span className="text-green-500 text-sm">Success</span>
+                            ) : (
+                              <span className="text-crate-amber text-sm">Running</span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* How It Works */}
+          <div className="card p-5">
+            <h3 className="text-sm font-medium text-crate-cream mb-3">How It Works</h3>
+            <ul className="text-sm text-crate-muted space-y-2">
+              <li>1. Connect your Spotify account using the button above</li>
+              <li>2. Enable automatic sync to run daily</li>
+              <li>3. Liked songs will be searched and downloaded as MP3s</li>
+              <li>4. Tracks are added to a "Spotify Liked Songs" crate</li>
+              <li>5. Already-synced tracks are skipped automatically</li>
+            </ul>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
This PR adds Spotify integration following the exact same design pattern as the existing SoundCloud integration.

## Features
- **OAuth 2.0 PKCE Flow**: Secure authentication without client secret exposure
- **Liked Songs Sync**: Automatically sync your Spotify liked songs to CrateDrop
- **Daily Auto-Sync**: Background job runs every 24 hours when enabled
- **Duplicate Detection**: Tracks already-synced songs to avoid re-downloading
- **Sync History**: View past sync results with success/failure status

## Backend Changes
- New `backend/spotify/` module mirroring SoundCloud structure:
  - `handlers.go`: HTTP request handlers
  - `manager.go`: Core sync logic with Spotify API integration
  - `repository.go`: Database operations
  - `routes.go`: API route definitions
  - `ticker.go`: Background sync loop
- Database migration (`003_add_spotify_sync.sql`) for:
  - `spotify_sync_config`: OAuth tokens and settings
  - `spotify_sync_history`: Sync run history
  - `spotify_synced_tracks`: Track deduplication
  - `spotify_synced_playlists`: For future playlist sync support

## Frontend Changes
- New `SpotifyPage.tsx` following SoundCloudPage.tsx pattern
- Updated `api.ts` with Spotify API functions
- Added Spotify to navigation in `Layout.tsx`
- Added route in `App.tsx`

## Configuration
Requires `SPOTIFY_CLIENT_ID` environment variable set on the server.

## API Endpoints
- `GET /api/spotify/config` - Get current configuration
- `PUT /api/spotify/config` - Update enabled status
- `POST /api/spotify/token` - Exchange OAuth code for tokens
- `POST /api/spotify/disconnect` - Disconnect Spotify account
- `POST /api/spotify/sync` - Trigger manual sync
- `GET /api/spotify/history` - Get sync history

## Scopes Used
- `user-library-read`: Access liked songs
- `playlist-read-private`: Access private playlists (future)
- `playlist-read-collaborative`: Access collaborative playlists (future)