### PR TITLE
feat: BPM & musical key analysis for DJ workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,25 +191,39 @@ docker compose logs backend | grep "upload"
 
 ### Optional: BPM & Musical Key Analysis
 
-CrateDrop can auto-detect BPM and musical key (Camelot notation) for uploaded
-tracks. This requires the `streaming_extractor_music` binary from essentia on
-the server's `PATH`. The provided Dockerfile installs it via `apt` when the
-image builds.
+CrateDrop can auto-detect BPM and musical key (Camelot notation) on upload, so
+DJs can filter their library by tempo and harmonically compatible keys. The
+worker shells out to `streaming_extractor_music` from
+[essentia](https://essentia.upf.edu/). Users can override a wrong detection by
+double-clicking the BPM or Key cell in the library.
 
-- **Docker (default):** the image ships with essentia pre-installed. No action
-  needed unless the build logs show `WARNING: essentia-examples not installed`.
-- **Bare metal:**
-  - Debian / Raspberry Pi OS: `sudo apt install essentia-examples`
-  - macOS (dev): `brew install essentia --HEAD`
+**The Docker image does NOT bundle essentia by default.** The package is not
+in Debian's repos, and the official `mtgupf/essentia` image is amd64-only
+(won't run on the Pi arm64 target). To enable analysis you must provide the
+binary yourself. Three options:
 
-If the binary is missing, the server still starts — it logs `WARNING:
-streaming_extractor_music not on PATH — analysis disabled` and skips the
-analysis worker. Uploads and playback continue to work normally; tracks stay
-in `pending` status until the binary is available. Install it and restart
-the server to drain the backlog.
+1. **Bind-mount from the host** (simplest). On the host, install essentia
+   into `/opt/essentia/bin/streaming_extractor_music`, then add to
+   `docker-compose.yml`:
+   ```yaml
+   volumes:
+     - /opt/essentia/bin/streaming_extractor_music:/usr/local/bin/streaming_extractor_music:ro
+   ```
+2. **Extend the Dockerfile** with a from-source build of essentia (~15 min
+   build time, adds ~400 MB to the image). Requires `libsamplerate0-dev`,
+   `libyaml-dev`, `libfftw3-dev`, `libavcodec-dev`, `libavformat-dev`,
+   `libavutil-dev`, `libavresample-dev`, `libsamplerate0-dev`, `libtag1-dev`,
+   `libchromaprint-dev`, `python3-dev`, plus the `waf` build system.
+3. **Bare metal deployment** (no Docker):
+   - Debian: clone <https://github.com/MTG/essentia> and run
+     `./waf configure --with-examples && ./waf && sudo ./waf install`.
+   - macOS (dev only): same source build.
 
-Users can override a wrong detection by double-clicking the BPM or Key cell
-in the library view.
+If the binary is missing the server still starts and logs `WARNING:
+streaming_extractor_music not on PATH — analysis disabled`. Uploads and
+playback continue to work; tracks stay in `pending` analysis status until
+the binary becomes available. Install it, restart the server, and the
+ticker drains the backlog automatically.
 
 ## 🐛 Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,28 @@ docker compose logs backend | grep "upload"
 └── logs/            # Application logs
 ```
 
+### Optional: BPM & Musical Key Analysis
+
+CrateDrop can auto-detect BPM and musical key (Camelot notation) for uploaded
+tracks. This requires the `streaming_extractor_music` binary from essentia on
+the server's `PATH`. The provided Dockerfile installs it via `apt` when the
+image builds.
+
+- **Docker (default):** the image ships with essentia pre-installed. No action
+  needed unless the build logs show `WARNING: essentia-examples not installed`.
+- **Bare metal:**
+  - Debian / Raspberry Pi OS: `sudo apt install essentia-examples`
+  - macOS (dev): `brew install essentia --HEAD`
+
+If the binary is missing, the server still starts — it logs `WARNING:
+streaming_extractor_music not on PATH — analysis disabled` and skips the
+analysis worker. Uploads and playback continue to work normally; tracks stay
+in `pending` status until the binary is available. Install it and restart
+the server to drain the backlog.
+
+Users can override a wrong detection by double-clicking the BPM or Key cell
+in the library view.
+
 ## 🐛 Troubleshooting
 
 ### Common Issues

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,16 +24,15 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install --break-system-packages yt-dlp
 
-# BPM / musical-key analysis prereq. `essentia-examples` provides the
-# `streaming_extractor_music` binary that the analysis worker shells out to.
-# Kept as a separate optional layer: if the package is unavailable (e.g. on
-# a repo without contrib/non-free, or a future Debian release that renames it)
-# the image still builds and the analysis worker disables itself with a
-# startup warning. Install it manually later to enable the feature.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends essentia-examples \
-    && rm -rf /var/lib/apt/lists/* \
-    || echo "WARNING: essentia-examples not installed; BPM/key analysis will be disabled."
+# BPM / musical-key analysis is OPT-IN and NOT bundled by default.
+#
+# The worker shells out to essentia's `streaming_extractor_music` binary. It
+# is not in the Debian repos and the official mtgupf/essentia Docker image is
+# amd64-only (won't work on the Raspberry Pi arm64 target).
+#
+# If the binary is present on PATH the worker enables itself automatically; if
+# absent, the server logs "WARNING: streaming_extractor_music not on PATH" and
+# the feature stays disabled. See README for install options.
 
 WORKDIR /app
 COPY --from=builder /out/server /app/server

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,6 +24,17 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install --break-system-packages yt-dlp
 
+# BPM / musical-key analysis prereq. `essentia-examples` provides the
+# `streaming_extractor_music` binary that the analysis worker shells out to.
+# Kept as a separate optional layer: if the package is unavailable (e.g. on
+# a repo without contrib/non-free, or a future Debian release that renames it)
+# the image still builds and the analysis worker disables itself with a
+# startup warning. Install it manually later to enable the feature.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends essentia-examples \
+    && rm -rf /var/lib/apt/lists/* \
+    || echo "WARNING: essentia-examples not installed; BPM/key analysis will be disabled."
+
 WORKDIR /app
 COPY --from=builder /out/server /app/server
 COPY soundcloud/downloader.py /app/soundcloud/downloader.py

--- a/backend/analysis/camelot.go
+++ b/backend/analysis/camelot.go
@@ -1,30 +1,33 @@
 package analysis
 
+var majorToCamelot = map[string]string{
+	"C": "8B", "G": "9B", "D": "10B", "A": "11B", "E": "12B", "B": "1B",
+	"F#": "2B", "Gb": "2B",
+	"Db": "3B", "C#": "3B",
+	"Ab": "4B", "G#": "4B",
+	"Eb": "5B", "D#": "5B",
+	"Bb": "6B", "A#": "6B",
+	"F": "7B",
+}
+
+var minorToCamelot = map[string]string{
+	"A": "8A", "E": "9A", "B": "10A",
+	"F#": "11A", "Gb": "11A",
+	"C#": "12A", "Db": "12A",
+	"G#": "1A", "Ab": "1A",
+	"Eb": "2A", "D#": "2A",
+	"Bb": "3A", "A#": "3A",
+	"F": "4A", "C": "5A", "G": "6A", "D": "7A",
+}
+
 // ToCamelot converts a musical key + scale ("A" + "minor") to Camelot wheel
 // notation ("8A"). Returns empty string for unrecognized inputs.
 //
 // The Camelot wheel indexes the 12 major keys as 1B..12B and the 12 minor
 // keys as 1A..12A, ordered so that +1/-1 and same-number-other-letter keys
-// are harmonically compatible.
+// are harmonically compatible. Scale comparison is case-sensitive: only the
+// exact strings "major" and "minor" are recognized.
 func ToCamelot(key, scale string) string {
-	majorToCamelot := map[string]string{
-		"C": "8B", "G": "9B", "D": "10B", "A": "11B", "E": "12B", "B": "1B",
-		"F#": "2B", "Gb": "2B",
-		"Db": "3B", "C#": "3B",
-		"Ab": "4B", "G#": "4B",
-		"Eb": "5B", "D#": "5B",
-		"Bb": "6B", "A#": "6B",
-		"F": "7B",
-	}
-	minorToCamelot := map[string]string{
-		"A": "8A", "E": "9A", "B": "10A",
-		"F#": "11A", "Gb": "11A",
-		"C#": "12A", "Db": "12A",
-		"G#": "1A", "Ab": "1A",
-		"Eb": "2A", "D#": "2A",
-		"Bb": "3A", "A#": "3A",
-		"F": "4A", "C": "5A", "G": "6A", "D": "7A",
-	}
 	switch scale {
 	case "major":
 		return majorToCamelot[key]

--- a/backend/analysis/camelot.go
+++ b/backend/analysis/camelot.go
@@ -1,0 +1,36 @@
+package analysis
+
+// ToCamelot converts a musical key + scale ("A" + "minor") to Camelot wheel
+// notation ("8A"). Returns empty string for unrecognized inputs.
+//
+// The Camelot wheel indexes the 12 major keys as 1B..12B and the 12 minor
+// keys as 1A..12A, ordered so that +1/-1 and same-number-other-letter keys
+// are harmonically compatible.
+func ToCamelot(key, scale string) string {
+	majorToCamelot := map[string]string{
+		"C": "8B", "G": "9B", "D": "10B", "A": "11B", "E": "12B", "B": "1B",
+		"F#": "2B", "Gb": "2B",
+		"Db": "3B", "C#": "3B",
+		"Ab": "4B", "G#": "4B",
+		"Eb": "5B", "D#": "5B",
+		"Bb": "6B", "A#": "6B",
+		"F": "7B",
+	}
+	minorToCamelot := map[string]string{
+		"A": "8A", "E": "9A", "B": "10A",
+		"F#": "11A", "Gb": "11A",
+		"C#": "12A", "Db": "12A",
+		"G#": "1A", "Ab": "1A",
+		"Eb": "2A", "D#": "2A",
+		"Bb": "3A", "A#": "3A",
+		"F": "4A", "C": "5A", "G": "6A", "D": "7A",
+	}
+	switch scale {
+	case "major":
+		return majorToCamelot[key]
+	case "minor":
+		return minorToCamelot[key]
+	default:
+		return ""
+	}
+}

--- a/backend/analysis/camelot_test.go
+++ b/backend/analysis/camelot_test.go
@@ -1,0 +1,60 @@
+package analysis
+
+import "testing"
+
+func TestToCamelot(t *testing.T) {
+	cases := []struct {
+		key, scale, want string
+	}{
+		// Major -> B side
+		{"C", "major", "8B"},
+		{"G", "major", "9B"},
+		{"D", "major", "10B"},
+		{"A", "major", "11B"},
+		{"E", "major", "12B"},
+		{"B", "major", "1B"},
+		{"F#", "major", "2B"},
+		{"Db", "major", "3B"},
+		{"Ab", "major", "4B"},
+		{"Eb", "major", "5B"},
+		{"Bb", "major", "6B"},
+		{"F", "major", "7B"},
+		// Minor -> A side
+		{"A", "minor", "8A"},
+		{"E", "minor", "9A"},
+		{"B", "minor", "10A"},
+		{"F#", "minor", "11A"},
+		{"C#", "minor", "12A"},
+		{"G#", "minor", "1A"},
+		{"Eb", "minor", "2A"},
+		{"Bb", "minor", "3A"},
+		{"F", "minor", "4A"},
+		{"C", "minor", "5A"},
+		{"G", "minor", "6A"},
+		{"D", "minor", "7A"},
+		// Enharmonic equivalents accepted
+		{"Gb", "major", "2B"}, // same as F#
+		{"C#", "major", "3B"}, // same as Db
+		{"D#", "minor", "2A"}, // same as Eb
+	}
+	for _, tc := range cases {
+		got := ToCamelot(tc.key, tc.scale)
+		if got != tc.want {
+			t.Errorf("ToCamelot(%q, %q) = %q, want %q", tc.key, tc.scale, got, tc.want)
+		}
+	}
+}
+
+func TestToCamelot_Invalid(t *testing.T) {
+	cases := []struct{ key, scale string }{
+		{"", "major"},
+		{"H", "major"},
+		{"C", "phrygian"},
+		{"C", ""},
+	}
+	for _, tc := range cases {
+		if got := ToCamelot(tc.key, tc.scale); got != "" {
+			t.Errorf("ToCamelot(%q, %q) = %q, want empty", tc.key, tc.scale, got)
+		}
+	}
+}

--- a/backend/analysis/essentia.go
+++ b/backend/analysis/essentia.go
@@ -30,7 +30,8 @@ func NewAnalyzer(timeout time.Duration) *Analyzer {
 }
 
 // BinaryAvailable reports whether the essentia binary is on PATH. Call once
-// at startup to decide whether to start the ticker.
+// at startup to decide whether to start the ticker. Analyze() re-checks, so
+// this is an optimization signal only — not a guarantee.
 func BinaryAvailable() bool {
 	_, err := exec.LookPath(binaryName)
 	return err == nil
@@ -53,6 +54,8 @@ func (a *Analyzer) Analyze(ctx context.Context, audioPath string) (Result, error
 		return Result{}, fmt.Errorf("mktemp: %w", err)
 	}
 	defer os.RemoveAll(outDir)
+	// The .json suffix is load-bearing: streaming_extractor_music infers the
+	// output format from the extension.
 	outPath := filepath.Join(outDir, "out.json")
 
 	runCtx, cancel := context.WithTimeout(ctx, a.timeout)
@@ -60,8 +63,13 @@ func (a *Analyzer) Analyze(ctx context.Context, audioPath string) (Result, error
 
 	cmd := exec.CommandContext(runCtx, binaryName, audioPath, outPath)
 	output, err := cmd.CombinedOutput()
-	if runCtx.Err() == context.DeadlineExceeded {
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
 		return Result{}, ErrTimeout
+	}
+	// Preserve parent-ctx cancellation so the manager can distinguish shutdown
+	// from an actual analysis failure.
+	if ctx.Err() != nil {
+		return Result{}, ctx.Err()
 	}
 	if err != nil {
 		return Result{}, fmt.Errorf("essentia exec failed: %w (output: %s)", err, string(output))
@@ -69,6 +77,9 @@ func (a *Analyzer) Analyze(ctx context.Context, audioPath string) (Result, error
 
 	raw, err := os.ReadFile(outPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return Result{}, fmt.Errorf("%w: output file not created (stderr: %s)", ErrMalformedOutput, string(output))
+		}
 		return Result{}, fmt.Errorf("read essentia output: %w", err)
 	}
 	result, err := ParseEssentiaOutput(raw)

--- a/backend/analysis/essentia.go
+++ b/backend/analysis/essentia.go
@@ -1,0 +1,79 @@
+package analysis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// Sentinel errors so callers (the manager) can decide retry policy.
+var (
+	ErrBinaryMissing   = errors.New("essentia binary not found on PATH")
+	ErrFileMissing     = errors.New("audio file not found")
+	ErrTimeout         = errors.New("essentia analysis timed out")
+	ErrMalformedOutput = errors.New("essentia produced malformed output")
+)
+
+const binaryName = "streaming_extractor_music"
+
+// Analyzer wraps the streaming_extractor_music binary.
+type Analyzer struct {
+	timeout time.Duration
+}
+
+func NewAnalyzer(timeout time.Duration) *Analyzer {
+	return &Analyzer{timeout: timeout}
+}
+
+// BinaryAvailable reports whether the essentia binary is on PATH. Call once
+// at startup to decide whether to start the ticker.
+func BinaryAvailable() bool {
+	_, err := exec.LookPath(binaryName)
+	return err == nil
+}
+
+// Analyze runs the essentia extractor on the given audio file path.
+func (a *Analyzer) Analyze(ctx context.Context, audioPath string) (Result, error) {
+	if _, err := exec.LookPath(binaryName); err != nil {
+		return Result{}, ErrBinaryMissing
+	}
+	if _, err := os.Stat(audioPath); err != nil {
+		if os.IsNotExist(err) {
+			return Result{}, ErrFileMissing
+		}
+		return Result{}, fmt.Errorf("stat audio: %w", err)
+	}
+
+	outDir, err := os.MkdirTemp("", "essentia-*")
+	if err != nil {
+		return Result{}, fmt.Errorf("mktemp: %w", err)
+	}
+	defer os.RemoveAll(outDir)
+	outPath := filepath.Join(outDir, "out.json")
+
+	runCtx, cancel := context.WithTimeout(ctx, a.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, binaryName, audioPath, outPath)
+	output, err := cmd.CombinedOutput()
+	if runCtx.Err() == context.DeadlineExceeded {
+		return Result{}, ErrTimeout
+	}
+	if err != nil {
+		return Result{}, fmt.Errorf("essentia exec failed: %w (output: %s)", err, string(output))
+	}
+
+	raw, err := os.ReadFile(outPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("read essentia output: %w", err)
+	}
+	result, err := ParseEssentiaOutput(raw)
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: %v", ErrMalformedOutput, err)
+	}
+	return result, nil
+}

--- a/backend/analysis/essentia_parse.go
+++ b/backend/analysis/essentia_parse.go
@@ -1,0 +1,61 @@
+package analysis
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Result is the structured output of an essentia analysis run.
+type Result struct {
+	BPM           float64
+	BPMConfidence float64 // normalized to [0, 1]
+	Key           string  // Camelot notation, e.g. "8A"; "" if unknown
+	KeyConfidence float64 // normalized to [0, 1]; 0 if key unknown
+}
+
+type rawEssentia struct {
+	Rhythm struct {
+		BPM           float64 `json:"bpm"`
+		BPMConfidence float64 `json:"bpm_confidence"`
+	} `json:"rhythm"`
+	Tonal struct {
+		KeyKey      string  `json:"key_key"`
+		KeyScale    string  `json:"key_scale"`
+		KeyStrength float64 `json:"key_strength"`
+	} `json:"tonal"`
+}
+
+// ParseEssentiaOutput reads the JSON written by streaming_extractor_music and
+// returns a normalized Result. Returns an error for malformed JSON or missing
+// BPM (the only truly required field).
+func ParseEssentiaOutput(raw []byte) (Result, error) {
+	var e rawEssentia
+	if err := json.Unmarshal(raw, &e); err != nil {
+		return Result{}, fmt.Errorf("parse essentia json: %w", err)
+	}
+	if e.Rhythm.BPM <= 0 {
+		return Result{}, errors.New("essentia output missing bpm")
+	}
+	camelot := ToCamelot(e.Tonal.KeyKey, e.Tonal.KeyScale)
+	keyConf := normalizeConfidence(e.Tonal.KeyStrength)
+	if camelot == "" {
+		keyConf = 0
+	}
+	return Result{
+		BPM:           e.Rhythm.BPM,
+		BPMConfidence: normalizeConfidence(e.Rhythm.BPMConfidence / 5.0),
+		Key:           camelot,
+		KeyConfidence: keyConf,
+	}, nil
+}
+
+func normalizeConfidence(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}

--- a/backend/analysis/essentia_parse.go
+++ b/backend/analysis/essentia_parse.go
@@ -4,14 +4,21 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 )
+
+// essentiaBPMConfidenceScale is the approximate upper bound of essentia's
+// rhythmextractor2013 bpm_confidence metric (a histogram-peak score, not a
+// probability). Dividing by this scale and clamping maps it into [0, 1].
+// Ref: https://essentia.upf.edu/reference/streaming_RhythmExtractor2013.html
+const essentiaBPMConfidenceScale = 5.0
 
 // Result is the structured output of an essentia analysis run.
 type Result struct {
 	BPM           float64
-	BPMConfidence float64 // normalized to [0, 1]
+	BPMConfidence float64 // in [0, 1]
 	Key           string  // Camelot notation, e.g. "8A"; "" if unknown
-	KeyConfidence float64 // normalized to [0, 1]; 0 if key unknown
+	KeyConfidence float64 // in [0, 1]; 0 if key unknown
 }
 
 type rawEssentia struct {
@@ -27,31 +34,32 @@ type rawEssentia struct {
 }
 
 // ParseEssentiaOutput reads the JSON written by streaming_extractor_music and
-// returns a normalized Result. Returns an error for malformed JSON or missing
-// BPM (the only truly required field).
+// returns a normalized Result. Returns an error for malformed JSON or a
+// missing / non-positive / NaN BPM (the only truly required field).
 func ParseEssentiaOutput(raw []byte) (Result, error) {
 	var e rawEssentia
 	if err := json.Unmarshal(raw, &e); err != nil {
 		return Result{}, fmt.Errorf("parse essentia json: %w", err)
 	}
-	if e.Rhythm.BPM <= 0 {
-		return Result{}, errors.New("essentia output missing bpm")
+	if math.IsNaN(e.Rhythm.BPM) || e.Rhythm.BPM <= 0 {
+		return Result{}, errors.New("essentia output missing or non-positive bpm")
 	}
 	camelot := ToCamelot(e.Tonal.KeyKey, e.Tonal.KeyScale)
-	keyConf := normalizeConfidence(e.Tonal.KeyStrength)
+	keyConf := clamp01(e.Tonal.KeyStrength)
 	if camelot == "" {
 		keyConf = 0
 	}
 	return Result{
 		BPM:           e.Rhythm.BPM,
-		BPMConfidence: normalizeConfidence(e.Rhythm.BPMConfidence / 5.0),
+		BPMConfidence: clamp01(e.Rhythm.BPMConfidence / essentiaBPMConfidenceScale),
 		Key:           camelot,
 		KeyConfidence: keyConf,
 	}, nil
 }
 
-func normalizeConfidence(x float64) float64 {
-	if x < 0 {
+// clamp01 coerces x into [0, 1], treating NaN as 0.
+func clamp01(x float64) float64 {
+	if math.IsNaN(x) || x < 0 {
 		return 0
 	}
 	if x > 1 {

--- a/backend/analysis/essentia_parse_test.go
+++ b/backend/analysis/essentia_parse_test.go
@@ -1,0 +1,78 @@
+package analysis
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseEssentiaOutput_Success(t *testing.T) {
+	raw, err := os.ReadFile("testdata/essentia_success.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	got, err := ParseEssentiaOutput(raw)
+	if err != nil {
+		t.Fatalf("ParseEssentiaOutput: %v", err)
+	}
+	if got.BPM != 128.04 {
+		t.Errorf("BPM = %v, want 128.04", got.BPM)
+	}
+	// bpm_confidence of 3.82 should normalize to min(3.82/5.0, 1.0) = 0.764
+	if got.BPMConfidence < 0.76 || got.BPMConfidence > 0.77 {
+		t.Errorf("BPMConfidence = %v, want ~0.764", got.BPMConfidence)
+	}
+	if got.Key != "8A" {
+		t.Errorf("Key = %q, want %q", got.Key, "8A")
+	}
+	if got.KeyConfidence != 0.78 {
+		t.Errorf("KeyConfidence = %v, want 0.78", got.KeyConfidence)
+	}
+}
+
+func TestParseEssentiaOutput_MalformedJSON(t *testing.T) {
+	_, err := ParseEssentiaOutput([]byte("{not json"))
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestParseEssentiaOutput_MissingBPM(t *testing.T) {
+	raw := []byte(`{"tonal":{"key_key":"A","key_scale":"minor","key_strength":0.5}}`)
+	_, err := ParseEssentiaOutput(raw)
+	if err == nil {
+		t.Fatal("expected error when BPM is missing")
+	}
+}
+
+func TestParseEssentiaOutput_UnknownKey_StillReturnsBPM(t *testing.T) {
+	// An invalid scale should leave Key empty but BPM still populated.
+	raw := []byte(`{"rhythm":{"bpm":120,"bpm_confidence":2.0},"tonal":{"key_key":"C","key_scale":"phrygian","key_strength":0.5}}`)
+	got, err := ParseEssentiaOutput(raw)
+	if err != nil {
+		t.Fatalf("ParseEssentiaOutput: %v", err)
+	}
+	if got.BPM != 120 {
+		t.Errorf("BPM = %v, want 120", got.BPM)
+	}
+	if got.Key != "" {
+		t.Errorf("Key = %q, want empty (unknown scale)", got.Key)
+	}
+	if got.KeyConfidence != 0 {
+		t.Errorf("KeyConfidence = %v, want 0 when key unknown", got.KeyConfidence)
+	}
+}
+
+func TestParseEssentiaOutput_ConfidenceClamped(t *testing.T) {
+	// bpm_confidence > 5.0 should clamp to 1.0
+	raw := []byte(`{"rhythm":{"bpm":120,"bpm_confidence":8.0},"tonal":{"key_key":"A","key_scale":"minor","key_strength":1.5}}`)
+	got, err := ParseEssentiaOutput(raw)
+	if err != nil {
+		t.Fatalf("ParseEssentiaOutput: %v", err)
+	}
+	if got.BPMConfidence != 1.0 {
+		t.Errorf("BPMConfidence = %v, want 1.0", got.BPMConfidence)
+	}
+	if got.KeyConfidence != 1.0 {
+		t.Errorf("KeyConfidence = %v, want 1.0", got.KeyConfidence)
+	}
+}

--- a/backend/analysis/essentia_test.go
+++ b/backend/analysis/essentia_test.go
@@ -29,9 +29,7 @@ func writeStubBinary(t *testing.T, outputJSON string) string {
 
 func withPathPrepended(t *testing.T, dir string) {
 	t.Helper()
-	prev := os.Getenv("PATH")
-	os.Setenv("PATH", dir+string(os.PathListSeparator)+prev)
-	t.Cleanup(func() { os.Setenv("PATH", prev) })
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func TestAnalyzer_Analyze_Success(t *testing.T) {
@@ -55,8 +53,7 @@ func TestAnalyzer_Analyze_Success(t *testing.T) {
 }
 
 func TestAnalyzer_Analyze_BinaryMissing(t *testing.T) {
-	os.Setenv("PATH", "/nonexistent")
-	t.Cleanup(func() { os.Setenv("PATH", "/usr/bin:/bin") })
+	t.Setenv("PATH", "/nonexistent")
 
 	a := NewAnalyzer(30 * time.Second)
 	_, err := a.Analyze(context.Background(), "/tmp/anything.wav")

--- a/backend/analysis/essentia_test.go
+++ b/backend/analysis/essentia_test.go
@@ -1,0 +1,93 @@
+package analysis
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// writeStubBinary creates a fake streaming_extractor_music in a temp dir that
+// writes the supplied JSON to its second argument and exits 0. Returns the
+// directory path so the caller can prepend it to PATH.
+func writeStubBinary(t *testing.T, outputJSON string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("stub shell script requires a POSIX shell")
+	}
+	dir := t.TempDir()
+	script := "#!/usr/bin/env bash\nprintf '%s' '" + outputJSON + "' > \"$2\"\n"
+	path := filepath.Join(dir, "streaming_extractor_music")
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return dir
+}
+
+func withPathPrepended(t *testing.T, dir string) {
+	t.Helper()
+	prev := os.Getenv("PATH")
+	os.Setenv("PATH", dir+string(os.PathListSeparator)+prev)
+	t.Cleanup(func() { os.Setenv("PATH", prev) })
+}
+
+func TestAnalyzer_Analyze_Success(t *testing.T) {
+	stubDir := writeStubBinary(t, `{"rhythm":{"bpm":124.0,"bpm_confidence":4.0},"tonal":{"key_key":"C","key_scale":"major","key_strength":0.9}}`)
+	withPathPrepended(t, stubDir)
+
+	audio := filepath.Join(t.TempDir(), "fake.wav")
+	os.WriteFile(audio, []byte("fake"), 0644)
+
+	a := NewAnalyzer(30 * time.Second)
+	got, err := a.Analyze(context.Background(), audio)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if got.BPM != 124.0 {
+		t.Errorf("BPM = %v, want 124.0", got.BPM)
+	}
+	if got.Key != "8B" {
+		t.Errorf("Key = %q, want 8B", got.Key)
+	}
+}
+
+func TestAnalyzer_Analyze_BinaryMissing(t *testing.T) {
+	os.Setenv("PATH", "/nonexistent")
+	t.Cleanup(func() { os.Setenv("PATH", "/usr/bin:/bin") })
+
+	a := NewAnalyzer(30 * time.Second)
+	_, err := a.Analyze(context.Background(), "/tmp/anything.wav")
+	if !errors.Is(err, ErrBinaryMissing) {
+		t.Fatalf("want ErrBinaryMissing, got %v", err)
+	}
+}
+
+func TestAnalyzer_Analyze_FileMissing(t *testing.T) {
+	// Stub exits 0 but we want the wrapper to return ErrFileMissing before
+	// even calling the binary.
+	stubDir := writeStubBinary(t, `{"rhythm":{"bpm":120,"bpm_confidence":2.0},"tonal":{"key_key":"A","key_scale":"minor","key_strength":0.5}}`)
+	withPathPrepended(t, stubDir)
+
+	a := NewAnalyzer(30 * time.Second)
+	_, err := a.Analyze(context.Background(), "/tmp/definitely-does-not-exist-xyz.wav")
+	if !errors.Is(err, ErrFileMissing) {
+		t.Fatalf("want ErrFileMissing, got %v", err)
+	}
+}
+
+func TestAnalyzer_Analyze_MalformedOutput(t *testing.T) {
+	stubDir := writeStubBinary(t, `{not json`)
+	withPathPrepended(t, stubDir)
+
+	audio := filepath.Join(t.TempDir(), "fake.wav")
+	os.WriteFile(audio, []byte("fake"), 0644)
+
+	a := NewAnalyzer(30 * time.Second)
+	_, err := a.Analyze(context.Background(), audio)
+	if !errors.Is(err, ErrMalformedOutput) {
+		t.Fatalf("want ErrMalformedOutput, got %v", err)
+	}
+}

--- a/backend/analysis/manager.go
+++ b/backend/analysis/manager.go
@@ -1,0 +1,63 @@
+package analysis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// analyzer is the narrow interface the manager needs — lets tests swap in a fake.
+type analyzer interface {
+	Analyze(ctx context.Context, audioPath string) (Result, error)
+}
+
+type Manager struct {
+	repo     *Repository
+	analyzer analyzer
+	now      func() time.Time
+}
+
+func NewManager(repo *Repository, a analyzer) *Manager {
+	return &Manager{repo: repo, analyzer: a, now: time.Now}
+}
+
+// ProcessOne claims the next pending track (if any) and analyzes it.
+// Returns (processed, err). `processed` is true iff a track was claimed;
+// err is only returned for surface-breaking conditions like ErrBinaryMissing.
+// Per-track analysis failures are recorded in the DB and do NOT bubble up.
+func (m *Manager) ProcessOne(ctx context.Context) (bool, error) {
+	claim, err := m.repo.ClaimNextPending(ctx)
+	if err != nil {
+		return false, fmt.Errorf("claim next pending: %w", err)
+	}
+	if claim == nil {
+		return false, nil
+	}
+
+	result, analyzeErr := m.analyzer.Analyze(ctx, claim.FilePath)
+	if analyzeErr != nil {
+		// Surface ErrBinaryMissing so the ticker can back off instead of
+		// marching through every track as failed.
+		if errors.Is(analyzeErr, ErrBinaryMissing) {
+			return false, analyzeErr
+		}
+		if errors.Is(analyzeErr, ErrFileMissing) {
+			if err := m.repo.RecordTerminalFailure(ctx, claim.ID, analyzeErr.Error()); err != nil {
+				fmt.Printf("[analysis] record terminal failure for %s: %v\n", claim.ID, err)
+			}
+			return true, nil
+		}
+		// Timeout, malformed output, exec failure — all retryable.
+		if err := m.repo.RecordFailure(ctx, claim.ID, analyzeErr.Error(), m.now()); err != nil {
+			fmt.Printf("[analysis] record failure for %s: %v\n", claim.ID, err)
+		}
+		return true, nil
+	}
+
+	if err := m.repo.MarkAnalyzed(ctx, claim.ID, result); err != nil {
+		fmt.Printf("[analysis] mark analyzed for %s: %v\n", claim.ID, err)
+		return true, nil
+	}
+	return true, nil
+}

--- a/backend/analysis/manager_test.go
+++ b/backend/analysis/manager_test.go
@@ -1,0 +1,129 @@
+package analysis
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+// fakeAnalyzer returns canned results or errors for tests.
+type fakeAnalyzer struct {
+	result Result
+	err    error
+	calls  int
+}
+
+func (f *fakeAnalyzer) Analyze(ctx context.Context, path string) (Result, error) {
+	f.calls++
+	return f.result, f.err
+}
+
+func TestManager_ProcessOne_NoPending(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewRepository(db)
+	fa := &fakeAnalyzer{}
+	m := NewManager(repo, fa)
+
+	processed, err := m.ProcessOne(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+	if processed {
+		t.Error("expected processed=false when nothing to do")
+	}
+	if fa.calls != 0 {
+		t.Errorf("analyzer called %d times, want 0", fa.calls)
+	}
+}
+
+func TestManager_ProcessOne_Success(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/a.wav")
+	repo := NewRepository(db)
+	fa := &fakeAnalyzer{result: Result{BPM: 128, BPMConfidence: 0.8, Key: "8A", KeyConfidence: 0.7}}
+	m := NewManager(repo, fa)
+
+	processed, err := m.ProcessOne(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+	if !processed {
+		t.Error("expected processed=true")
+	}
+
+	var status string
+	var bpm sql.NullFloat64
+	_ = db.QueryRow(`SELECT analysis_status, bpm FROM tracks WHERE id='t1'`).Scan(&status, &bpm)
+	if status != "analyzed" || bpm.Float64 != 128 {
+		t.Errorf("status=%q bpm=%v", status, bpm)
+	}
+}
+
+func TestManager_ProcessOne_RetryableFailure(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/a.wav")
+	repo := NewRepository(db)
+	fa := &fakeAnalyzer{err: ErrTimeout}
+	m := NewManager(repo, fa)
+
+	_, err := m.ProcessOne(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+
+	var status string
+	var retryCount int
+	_ = db.QueryRow(`SELECT analysis_status, analysis_retry_count FROM tracks WHERE id='t1'`).Scan(&status, &retryCount)
+	if status != "pending" {
+		t.Errorf("status=%q, want pending after 1st retryable failure", status)
+	}
+	if retryCount != 1 {
+		t.Errorf("retry_count=%d, want 1", retryCount)
+	}
+}
+
+func TestManager_ProcessOne_TerminalFailureOnMissingFile(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/a.wav")
+	repo := NewRepository(db)
+	fa := &fakeAnalyzer{err: ErrFileMissing}
+	m := NewManager(repo, fa)
+
+	_, err := m.ProcessOne(context.Background())
+	if err != nil {
+		t.Fatalf("ProcessOne: %v", err)
+	}
+
+	var status string
+	var retryCount int
+	_ = db.QueryRow(`SELECT analysis_status, analysis_retry_count FROM tracks WHERE id='t1'`).Scan(&status, &retryCount)
+	if status != "failed" {
+		t.Errorf("status=%q, want failed (terminal)", status)
+	}
+	if retryCount != 0 {
+		t.Errorf("retry_count=%d, want 0 for terminal failure", retryCount)
+	}
+}
+
+func TestManager_ProcessOne_BinaryMissingReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/a.wav")
+	repo := NewRepository(db)
+	fa := &fakeAnalyzer{err: ErrBinaryMissing}
+	m := NewManager(repo, fa)
+
+	// ErrBinaryMissing means config is broken; surface it rather than burning
+	// retry budget on every track in the library.
+	_, err := m.ProcessOne(context.Background())
+	if !errors.Is(err, ErrBinaryMissing) {
+		t.Fatalf("want ErrBinaryMissing, got %v", err)
+	}
+
+	var status string
+	var retryCount int
+	_ = db.QueryRow(`SELECT analysis_status, analysis_retry_count FROM tracks WHERE id='t1'`).Scan(&status, &retryCount)
+	if status != "pending" || retryCount != 0 {
+		t.Errorf("status=%q retry=%d, want untouched", status, retryCount)
+	}
+}

--- a/backend/analysis/repository.go
+++ b/backend/analysis/repository.go
@@ -83,7 +83,9 @@ func (r *Repository) MarkAnalyzed(ctx context.Context, id string, res Result) er
 }
 
 // RecordFailure increments retry_count and schedules the next attempt. After
-// maxRetries failures the status flips to 'failed' (terminal).
+// maxRetries failures the status flips to 'failed' (terminal). Skips no-ops on
+// rows that are already terminal ('failed') or user-overridden ('user_edited')
+// so a late error from a cancelled analysis can't resurrect a closed track.
 func (r *Repository) RecordFailure(ctx context.Context, id, errMsg string, now time.Time) error {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -92,9 +94,13 @@ func (r *Repository) RecordFailure(ctx context.Context, id, errMsg string, now t
 	defer tx.Rollback()
 
 	var current int
-	err = tx.QueryRowContext(ctx, `SELECT analysis_retry_count FROM tracks WHERE id=?`, id).Scan(&current)
+	var status string
+	err = tx.QueryRowContext(ctx, `SELECT analysis_status, analysis_retry_count FROM tracks WHERE id=?`, id).Scan(&status, &current)
 	if err != nil {
 		return err
+	}
+	if status == "failed" || status == "user_edited" {
+		return tx.Commit()
 	}
 	next := current + 1
 	if next >= maxRetries {

--- a/backend/analysis/repository.go
+++ b/backend/analysis/repository.go
@@ -63,7 +63,9 @@ func (r *Repository) ClaimNextPending(ctx context.Context) (*ClaimedTrack, error
 
 // MarkAnalyzed writes a successful result and flips status to 'analyzed'.
 // If the key is empty (unknown), musical_key is set NULL but the row is still
-// considered analyzed.
+// considered analyzed. No-ops on terminal ('failed') or user-edited rows so a
+// late analysis completion can't overwrite a user override that landed while
+// the analyzer was still running.
 func (r *Repository) MarkAnalyzed(ctx context.Context, id string, res Result) error {
 	var key interface{}
 	if res.Key != "" {
@@ -77,7 +79,7 @@ func (r *Repository) MarkAnalyzed(ctx context.Context, id string, res Result) er
             analysis_error = NULL,
             next_retry_at = NULL,
             updated_at = datetime('now')
-        WHERE id = ?
+        WHERE id = ? AND analysis_status NOT IN ('user_edited', 'failed')
     `, res.BPM, res.BPMConfidence, key, res.KeyConfidence, id)
 	return err
 }

--- a/backend/analysis/repository.go
+++ b/backend/analysis/repository.go
@@ -1,0 +1,140 @@
+package analysis
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+const maxRetries = 3
+
+// backoffFor returns the time until the next retry attempt given how many
+// failures have already been recorded (1-based).
+func backoffFor(retryCount int) time.Duration {
+	switch retryCount {
+	case 1:
+		return 10 * time.Minute
+	case 2:
+		return 1 * time.Hour
+	default:
+		return 6 * time.Hour
+	}
+}
+
+// ClaimedTrack holds the minimum info needed to run analysis.
+type ClaimedTrack struct {
+	ID       string
+	FilePath string
+}
+
+// Repository reads/writes analysis fields on the tracks table. It accepts a
+// *sql.DB directly (not the project's *db.DB wrapper) so tests can use an
+// in-memory SQLite.
+type Repository struct {
+	db *sql.DB
+}
+
+func NewRepository(db *sql.DB) *Repository {
+	return &Repository{db: db}
+}
+
+// ClaimNextPending returns the next track eligible for analysis, or nil if
+// none. Eligibility: analysis_status='pending' AND next_retry_at is null or
+// in the past. Sorted by upload order so backfill drains oldest first.
+func (r *Repository) ClaimNextPending(ctx context.Context) (*ClaimedTrack, error) {
+	row := r.db.QueryRowContext(ctx, `
+        SELECT id, file_path
+        FROM tracks
+        WHERE analysis_status = 'pending'
+          AND (next_retry_at IS NULL OR next_retry_at <= datetime('now'))
+        ORDER BY created_at ASC
+        LIMIT 1
+    `)
+	var t ClaimedTrack
+	err := row.Scan(&t.ID, &t.FilePath)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+// MarkAnalyzed writes a successful result and flips status to 'analyzed'.
+// If the key is empty (unknown), musical_key is set NULL but the row is still
+// considered analyzed.
+func (r *Repository) MarkAnalyzed(ctx context.Context, id string, res Result) error {
+	var key interface{}
+	if res.Key != "" {
+		key = res.Key
+	}
+	_, err := r.db.ExecContext(ctx, `
+        UPDATE tracks
+        SET bpm = ?, bpm_confidence = ?, musical_key = ?, key_confidence = ?,
+            analyzed_at = datetime('now'),
+            analysis_status = 'analyzed',
+            analysis_error = NULL,
+            next_retry_at = NULL,
+            updated_at = datetime('now')
+        WHERE id = ?
+    `, res.BPM, res.BPMConfidence, key, res.KeyConfidence, id)
+	return err
+}
+
+// RecordFailure increments retry_count and schedules the next attempt. After
+// maxRetries failures the status flips to 'failed' (terminal).
+func (r *Repository) RecordFailure(ctx context.Context, id, errMsg string, now time.Time) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	var current int
+	err = tx.QueryRowContext(ctx, `SELECT analysis_retry_count FROM tracks WHERE id=?`, id).Scan(&current)
+	if err != nil {
+		return err
+	}
+	next := current + 1
+	if next >= maxRetries {
+		_, err = tx.ExecContext(ctx, `
+            UPDATE tracks
+            SET analysis_status = 'failed',
+                analysis_retry_count = ?,
+                analysis_error = ?,
+                next_retry_at = NULL,
+                updated_at = datetime('now')
+            WHERE id = ?
+        `, next, errMsg, id)
+	} else {
+		retryAt := now.Add(backoffFor(next))
+		_, err = tx.ExecContext(ctx, `
+            UPDATE tracks
+            SET analysis_status = 'pending',
+                analysis_retry_count = ?,
+                analysis_error = ?,
+                next_retry_at = ?,
+                updated_at = datetime('now')
+            WHERE id = ?
+        `, next, errMsg, retryAt, id)
+	}
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// RecordTerminalFailure flips a track straight to 'failed' with no retries.
+// Use for non-recoverable errors (e.g. file missing on disk).
+func (r *Repository) RecordTerminalFailure(ctx context.Context, id, errMsg string) error {
+	_, err := r.db.ExecContext(ctx, `
+        UPDATE tracks
+        SET analysis_status = 'failed',
+            analysis_error = ?,
+            next_retry_at = NULL,
+            updated_at = datetime('now')
+        WHERE id = ?
+    `, errMsg, id)
+	return err
+}

--- a/backend/analysis/repository_test.go
+++ b/backend/analysis/repository_test.go
@@ -180,3 +180,100 @@ func TestRepository_RecordTerminalFailure_SetsFailedImmediately(t *testing.T) {
 		t.Errorf("status = %q, want failed", status)
 	}
 }
+
+func TestRepository_RecordFailure_BackoffSchedule(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/a.wav")
+	repo := NewRepository(db)
+
+	base := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
+
+	// 1st failure -> +10m
+	if err := repo.RecordFailure(context.Background(), "t1", "boom", base); err != nil {
+		t.Fatalf("1st RecordFailure: %v", err)
+	}
+	var nextRetry sql.NullTime
+	if err := db.QueryRow(`SELECT next_retry_at FROM tracks WHERE id='t1'`).Scan(&nextRetry); err != nil {
+		t.Fatalf("read next_retry_at: %v", err)
+	}
+	want := base.Add(10 * time.Minute)
+	if !nextRetry.Valid || !nextRetry.Time.Equal(want) {
+		t.Errorf("next_retry_at after 1st = %v, want %v", nextRetry.Time, want)
+	}
+
+	// 2nd failure -> +1h
+	if err := repo.RecordFailure(context.Background(), "t1", "boom", base); err != nil {
+		t.Fatalf("2nd RecordFailure: %v", err)
+	}
+	if err := db.QueryRow(`SELECT next_retry_at FROM tracks WHERE id='t1'`).Scan(&nextRetry); err != nil {
+		t.Fatalf("read next_retry_at: %v", err)
+	}
+	want = base.Add(1 * time.Hour)
+	if !nextRetry.Valid || !nextRetry.Time.Equal(want) {
+		t.Errorf("next_retry_at after 2nd = %v, want %v", nextRetry.Time, want)
+	}
+
+	// 3rd failure -> terminal, next_retry_at cleared
+	if err := repo.RecordFailure(context.Background(), "t1", "boom", base); err != nil {
+		t.Fatalf("3rd RecordFailure: %v", err)
+	}
+	var status string
+	if err := db.QueryRow(`SELECT analysis_status, next_retry_at FROM tracks WHERE id='t1'`).Scan(&status, &nextRetry); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if status != "failed" {
+		t.Errorf("status after 3rd = %q, want failed", status)
+	}
+	if nextRetry.Valid {
+		t.Errorf("next_retry_at after terminal = %v, want NULL", nextRetry.Time)
+	}
+}
+
+func TestRepository_RecordFailure_SkipsTerminalRows(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/a.wav")
+	repo := NewRepository(db)
+
+	// Flip straight to terminal via RecordTerminalFailure.
+	if err := repo.RecordTerminalFailure(context.Background(), "t1", "file missing"); err != nil {
+		t.Fatalf("RecordTerminalFailure: %v", err)
+	}
+
+	// A late RecordFailure call must NOT resurrect the row.
+	if err := repo.RecordFailure(context.Background(), "t1", "late error", time.Now()); err != nil {
+		t.Fatalf("RecordFailure: %v", err)
+	}
+
+	var status string
+	var retryCount int
+	if err := db.QueryRow(`SELECT analysis_status, analysis_retry_count FROM tracks WHERE id='t1'`).Scan(&status, &retryCount); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if status != "failed" {
+		t.Errorf("status = %q, want failed (not resurrected)", status)
+	}
+	if retryCount != 0 {
+		t.Errorf("retry_count = %d, want 0 (not touched)", retryCount)
+	}
+}
+
+func TestRepository_RecordFailure_SkipsUserEditedRows(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/a.wav")
+	if _, err := db.Exec(`UPDATE tracks SET analysis_status='user_edited' WHERE id='t1'`); err != nil {
+		t.Fatalf("seed user_edited: %v", err)
+	}
+	repo := NewRepository(db)
+
+	if err := repo.RecordFailure(context.Background(), "t1", "late error", time.Now()); err != nil {
+		t.Fatalf("RecordFailure: %v", err)
+	}
+
+	var status string
+	if err := db.QueryRow(`SELECT analysis_status FROM tracks WHERE id='t1'`).Scan(&status); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if status != "user_edited" {
+		t.Errorf("status = %q, want user_edited (preserved)", status)
+	}
+}

--- a/backend/analysis/repository_test.go
+++ b/backend/analysis/repository_test.go
@@ -277,3 +277,59 @@ func TestRepository_RecordFailure_SkipsUserEditedRows(t *testing.T) {
 		t.Errorf("status = %q, want user_edited (preserved)", status)
 	}
 }
+
+func TestRepository_MarkAnalyzed_SkipsUserEditedRows(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/a.wav")
+	// Simulate a user override landing mid-analysis.
+	if _, err := db.Exec(`UPDATE tracks SET analysis_status='user_edited', bpm=120.0, musical_key='5A' WHERE id='t1'`); err != nil {
+		t.Fatalf("seed user_edited: %v", err)
+	}
+	repo := NewRepository(db)
+
+	// Analyzer finishes and tries to write detected values — must be ignored.
+	err := repo.MarkAnalyzed(context.Background(), "t1", Result{
+		BPM: 128.0, BPMConfidence: 0.9, Key: "8A", KeyConfidence: 0.8,
+	})
+	if err != nil {
+		t.Fatalf("MarkAnalyzed: %v", err)
+	}
+
+	var status string
+	var bpm sql.NullFloat64
+	var key sql.NullString
+	if err := db.QueryRow(`SELECT analysis_status, bpm, musical_key FROM tracks WHERE id='t1'`).Scan(&status, &bpm, &key); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if status != "user_edited" {
+		t.Errorf("status = %q, want user_edited (user override preserved)", status)
+	}
+	if !bpm.Valid || bpm.Float64 != 120.0 {
+		t.Errorf("bpm = %v, want 120.0 (user value preserved)", bpm)
+	}
+	if !key.Valid || key.String != "5A" {
+		t.Errorf("musical_key = %v, want 5A (user value preserved)", key)
+	}
+}
+
+func TestRepository_MarkAnalyzed_SkipsFailedRows(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/a.wav")
+	if _, err := db.Exec(`UPDATE tracks SET analysis_status='failed' WHERE id='t1'`); err != nil {
+		t.Fatalf("seed failed: %v", err)
+	}
+	repo := NewRepository(db)
+
+	err := repo.MarkAnalyzed(context.Background(), "t1", Result{BPM: 128.0, Key: "8A"})
+	if err != nil {
+		t.Fatalf("MarkAnalyzed: %v", err)
+	}
+
+	var status string
+	if err := db.QueryRow(`SELECT analysis_status FROM tracks WHERE id='t1'`).Scan(&status); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if status != "failed" {
+		t.Errorf("status = %q, want failed (not revived)", status)
+	}
+}

--- a/backend/analysis/repository_test.go
+++ b/backend/analysis/repository_test.go
@@ -1,0 +1,182 @@
+package analysis
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// newTestDB sets up an in-memory SQLite with just enough schema for the repo.
+func newTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	_, err = db.Exec(`
+        CREATE TABLE tracks (
+            id TEXT PRIMARY KEY,
+            owner_user_id TEXT NOT NULL DEFAULT 'u1',
+            original_filename TEXT NOT NULL DEFAULT 'f.wav',
+            content_type TEXT NOT NULL DEFAULT 'audio/wav',
+            size_bytes INTEGER NOT NULL DEFAULT 0,
+            file_path TEXT NOT NULL DEFAULT '/x',
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            bpm REAL,
+            bpm_confidence REAL,
+            musical_key TEXT,
+            key_confidence REAL,
+            analyzed_at DATETIME,
+            analysis_status TEXT NOT NULL DEFAULT 'pending',
+            analysis_error TEXT,
+            analysis_retry_count INTEGER NOT NULL DEFAULT 0,
+            next_retry_at DATETIME
+        );
+    `)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func seedPending(t *testing.T, db *sql.DB, id, filePath string) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO tracks (id, file_path) VALUES (?, ?)`, id, filePath)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+func TestRepository_ClaimNextPending_ReturnsPending(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/audio/t1.wav")
+
+	repo := NewRepository(db)
+	got, err := repo.ClaimNextPending(context.Background())
+	if err != nil {
+		t.Fatalf("ClaimNextPending: %v", err)
+	}
+	if got == nil || got.ID != "t1" {
+		t.Fatalf("got %v, want track t1", got)
+	}
+	if got.FilePath != "/audio/t1.wav" {
+		t.Errorf("FilePath = %q", got.FilePath)
+	}
+}
+
+func TestRepository_ClaimNextPending_NoneAvailable(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewRepository(db)
+	got, err := repo.ClaimNextPending(context.Background())
+	if err != nil {
+		t.Fatalf("ClaimNextPending: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestRepository_ClaimNextPending_SkipsFutureRetry(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/a.wav")
+	// Push t1's next_retry_at into the future
+	_, _ = db.Exec(`UPDATE tracks SET next_retry_at = datetime('now', '+1 hour') WHERE id = 't1'`)
+
+	repo := NewRepository(db)
+	got, err := repo.ClaimNextPending(context.Background())
+	if err != nil {
+		t.Fatalf("ClaimNextPending: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("should skip track with future next_retry_at, got %v", got)
+	}
+}
+
+func TestRepository_MarkAnalyzed_UpdatesFields(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/a.wav")
+	repo := NewRepository(db)
+
+	camKey := "8A"
+	err := repo.MarkAnalyzed(context.Background(), "t1", Result{
+		BPM: 128.0, BPMConfidence: 0.8, Key: camKey, KeyConfidence: 0.78,
+	})
+	if err != nil {
+		t.Fatalf("MarkAnalyzed: %v", err)
+	}
+
+	var status string
+	var bpm sql.NullFloat64
+	var key sql.NullString
+	err = db.QueryRow(`SELECT analysis_status, bpm, musical_key FROM tracks WHERE id='t1'`).Scan(&status, &bpm, &key)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if status != "analyzed" {
+		t.Errorf("status = %q", status)
+	}
+	if !bpm.Valid || bpm.Float64 != 128.0 {
+		t.Errorf("bpm = %v", bpm)
+	}
+	if !key.Valid || key.String != "8A" {
+		t.Errorf("key = %v", key)
+	}
+}
+
+func TestRepository_RecordFailure_IncrementsAndBackoff(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/a.wav")
+	repo := NewRepository(db)
+
+	// First failure -> still pending, next_retry_at ~10min out
+	err := repo.RecordFailure(context.Background(), "t1", "boom", time.Now())
+	if err != nil {
+		t.Fatalf("RecordFailure: %v", err)
+	}
+	var status string
+	var retryCount int
+	var nextRetry sql.NullTime
+	_ = db.QueryRow(`SELECT analysis_status, analysis_retry_count, next_retry_at FROM tracks WHERE id='t1'`).Scan(&status, &retryCount, &nextRetry)
+	if status != "pending" {
+		t.Errorf("status after 1st failure = %q, want pending", status)
+	}
+	if retryCount != 1 {
+		t.Errorf("retry_count = %d, want 1", retryCount)
+	}
+	if !nextRetry.Valid {
+		t.Fatalf("next_retry_at not set")
+	}
+
+	// Third failure -> terminal
+	_ = repo.RecordFailure(context.Background(), "t1", "boom", time.Now())
+	_ = repo.RecordFailure(context.Background(), "t1", "boom", time.Now())
+
+	_ = db.QueryRow(`SELECT analysis_status, analysis_retry_count FROM tracks WHERE id='t1'`).Scan(&status, &retryCount)
+	if status != "failed" {
+		t.Errorf("status after 3rd failure = %q, want failed", status)
+	}
+	if retryCount != 3 {
+		t.Errorf("retry_count = %d, want 3", retryCount)
+	}
+}
+
+func TestRepository_RecordTerminalFailure_SetsFailedImmediately(t *testing.T) {
+	db := newTestDB(t)
+	seedPending(t, db, "t1", "/a.wav")
+	repo := NewRepository(db)
+
+	err := repo.RecordTerminalFailure(context.Background(), "t1", "file missing")
+	if err != nil {
+		t.Fatalf("RecordTerminalFailure: %v", err)
+	}
+	var status string
+	_ = db.QueryRow(`SELECT analysis_status FROM tracks WHERE id='t1'`).Scan(&status)
+	if status != "failed" {
+		t.Errorf("status = %q, want failed", status)
+	}
+}

--- a/backend/analysis/testdata/essentia_success.json
+++ b/backend/analysis/testdata/essentia_success.json
@@ -1,0 +1,11 @@
+{
+  "rhythm": {
+    "bpm": 128.04,
+    "bpm_confidence": 3.82
+  },
+  "tonal": {
+    "key_key": "A",
+    "key_scale": "minor",
+    "key_strength": 0.78
+  }
+}

--- a/backend/analysis/ticker.go
+++ b/backend/analysis/ticker.go
@@ -7,40 +7,47 @@ import (
 	"time"
 )
 
-// StartLoop polls for pending tracks on the given interval. Stops when ctx
-// is cancelled. If Analyze returns ErrBinaryMissing, the loop backs off to
-// a longer wait (since no amount of retrying will help until the binary is
-// installed and the server restarted).
+// StartLoop polls for pending tracks on the given interval. When ProcessOne
+// reports a track was handled, the loop immediately drains the next one
+// instead of waiting for the next tick — this matters during initial backfill,
+// where a library of N tracks would otherwise take N*interval of idle wait.
+//
+// Stops when ctx is cancelled or when ProcessOne reports ErrBinaryMissing
+// (binary won't appear without a server restart, so no point spinning).
 func StartLoop(ctx context.Context, m *Manager, interval time.Duration) {
 	fmt.Printf("[Analysis] Starting loop (interval=%s)\n", interval)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	backoff := time.Duration(0)
 	for {
+		if ctx.Err() != nil {
+			fmt.Println("[Analysis] Loop stopped")
+			return
+		}
+
+		processed, err := m.ProcessOne(ctx)
+		if err != nil {
+			if errors.Is(err, ErrBinaryMissing) {
+				fmt.Println("[Analysis] essentia binary not available; stopping loop until restart")
+				return
+			}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				fmt.Println("[Analysis] Loop stopped")
+				return
+			}
+			fmt.Printf("[Analysis] ProcessOne error: %v\n", err)
+		}
+
+		// Drain mode: if we just processed a track, loop again without waiting.
+		// If idle, block on the next tick (or shutdown).
+		if processed {
+			continue
+		}
 		select {
 		case <-ctx.Done():
 			fmt.Println("[Analysis] Loop stopped")
 			return
 		case <-ticker.C:
-			if backoff > 0 {
-				// Consume this tick to honor backoff.
-				backoff -= interval
-				if backoff < 0 {
-					backoff = 0
-				}
-				continue
-			}
-			processed, err := m.ProcessOne(ctx)
-			if err != nil {
-				if errors.Is(err, ErrBinaryMissing) {
-					fmt.Println("[Analysis] essentia binary not available; backing off for 5 minutes")
-					backoff = 5 * time.Minute
-					continue
-				}
-				fmt.Printf("[Analysis] ProcessOne error: %v\n", err)
-			}
-			_ = processed
 		}
 	}
 }

--- a/backend/analysis/ticker.go
+++ b/backend/analysis/ticker.go
@@ -1,0 +1,46 @@
+package analysis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// StartLoop polls for pending tracks on the given interval. Stops when ctx
+// is cancelled. If Analyze returns ErrBinaryMissing, the loop backs off to
+// a longer wait (since no amount of retrying will help until the binary is
+// installed and the server restarted).
+func StartLoop(ctx context.Context, m *Manager, interval time.Duration) {
+	fmt.Printf("[Analysis] Starting loop (interval=%s)\n", interval)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	backoff := time.Duration(0)
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("[Analysis] Loop stopped")
+			return
+		case <-ticker.C:
+			if backoff > 0 {
+				// Consume this tick to honor backoff.
+				backoff -= interval
+				if backoff < 0 {
+					backoff = 0
+				}
+				continue
+			}
+			processed, err := m.ProcessOne(ctx)
+			if err != nil {
+				if errors.Is(err, ErrBinaryMissing) {
+					fmt.Println("[Analysis] essentia binary not available; backing off for 5 minutes")
+					backoff = 5 * time.Minute
+					continue
+				}
+				fmt.Printf("[Analysis] ProcessOne error: %v\n", err)
+			}
+			_ = processed
+		}
+	}
+}

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -115,5 +115,22 @@ func (d *DB) migrate() error {
 		}
 	}
 
+	// Check if bpm column exists on tracks table
+	var bpmColCount int
+	_ = d.QueryRow(`
+		SELECT COUNT(*)
+		FROM pragma_table_info('tracks')
+		WHERE name='bpm'
+	`).Scan(&bpmColCount)
+	if bpmColCount == 0 {
+		migrationSQL, err := migrationsFS.ReadFile("migrations/003_add_track_analysis.sql")
+		if err != nil {
+			return fmt.Errorf("failed to read migration 003_add_track_analysis: %w", err)
+		}
+		if _, err := d.Exec(string(migrationSQL)); err != nil {
+			return fmt.Errorf("failed to execute migration 003_add_track_analysis: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/backend/internal/db/migrations/003_add_track_analysis.sql
+++ b/backend/internal/db/migrations/003_add_track_analysis.sql
@@ -1,0 +1,13 @@
+-- Track analysis fields for BPM + Musical Key detection
+ALTER TABLE tracks ADD COLUMN bpm REAL;
+ALTER TABLE tracks ADD COLUMN bpm_confidence REAL;
+ALTER TABLE tracks ADD COLUMN musical_key TEXT;              -- Camelot notation, e.g. "8A"
+ALTER TABLE tracks ADD COLUMN key_confidence REAL;
+ALTER TABLE tracks ADD COLUMN analyzed_at DATETIME;
+ALTER TABLE tracks ADD COLUMN analysis_status TEXT NOT NULL DEFAULT 'pending';
+ALTER TABLE tracks ADD COLUMN analysis_error TEXT;
+ALTER TABLE tracks ADD COLUMN analysis_retry_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE tracks ADD COLUMN next_retry_at DATETIME;
+
+CREATE INDEX IF NOT EXISTS idx_tracks_analysis_status
+    ON tracks(analysis_status, next_retry_at);

--- a/backend/internal/db/migrations/schema.sql
+++ b/backend/internal/db/migrations/schema.sql
@@ -35,6 +35,15 @@ CREATE TABLE IF NOT EXISTS tracks (
     year INTEGER,
     sample_rate INTEGER,
     bitrate INTEGER,
+    bpm REAL,
+    bpm_confidence REAL,
+    musical_key TEXT,
+    key_confidence REAL,
+    analyzed_at DATETIME,
+    analysis_status TEXT NOT NULL DEFAULT 'pending',
+    analysis_error TEXT,
+    analysis_retry_count INTEGER NOT NULL DEFAULT 0,
+    next_retry_at DATETIME,
     file_path TEXT NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -88,6 +97,8 @@ CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE INDEX IF NOT EXISTS idx_tracks_owner_created ON tracks(owner_user_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_tracks_created_at ON tracks(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_tracks_genre ON tracks(genre);
+CREATE INDEX IF NOT EXISTS idx_tracks_analysis_status
+    ON tracks(analysis_status, next_retry_at);
 
 -- Playlist indexes
 CREATE INDEX IF NOT EXISTS idx_playlists_owner_default ON playlists(owner_user_id, is_default);

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -13,22 +13,28 @@ type User struct {
 }
 
 type Track struct {
-	ID               string    `json:"id"`
-	OwnerUserID      string    `json:"owner_user_id"`
-	OriginalFilename string    `json:"original_filename"`
-	ContentType      string    `json:"content_type"`
-	SizeBytes        int64     `json:"size_bytes"`
-	DurationSeconds  *float64  `json:"duration_seconds,omitempty"`
-	Title            *string   `json:"title,omitempty"`
-	Artist           *string   `json:"artist,omitempty"`
-	Album            *string   `json:"album,omitempty"`
-	Genre            *string   `json:"genre,omitempty"`
-	Year             *int      `json:"year,omitempty"`
-	SampleRate       *int      `json:"sample_rate,omitempty"`
-	Bitrate          *int      `json:"bitrate,omitempty"`
-	FilePath         string    `json:"file_path"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	ID               string     `json:"id"`
+	OwnerUserID      string     `json:"owner_user_id"`
+	OriginalFilename string     `json:"original_filename"`
+	ContentType      string     `json:"content_type"`
+	SizeBytes        int64      `json:"size_bytes"`
+	DurationSeconds  *float64   `json:"duration_seconds,omitempty"`
+	Title            *string    `json:"title,omitempty"`
+	Artist           *string    `json:"artist,omitempty"`
+	Album            *string    `json:"album,omitempty"`
+	Genre            *string    `json:"genre,omitempty"`
+	Year             *int       `json:"year,omitempty"`
+	SampleRate       *int       `json:"sample_rate,omitempty"`
+	Bitrate          *int       `json:"bitrate,omitempty"`
+	BPM              *float64   `json:"bpm,omitempty"`
+	BPMConfidence    *float64   `json:"bpm_confidence,omitempty"`
+	MusicalKey       *string    `json:"musical_key,omitempty"`
+	KeyConfidence    *float64   `json:"key_confidence,omitempty"`
+	AnalyzedAt       *time.Time `json:"analyzed_at,omitempty"`
+	AnalysisStatus   string     `json:"analysis_status"`
+	FilePath         string     `json:"file_path"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
 }
 
 type RefreshToken struct {

--- a/backend/main.go
+++ b/backend/main.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/faraz525/home-music-server/backend/analysis"
 	"github.com/faraz525/home-music-server/backend/auth"
 	"github.com/faraz525/home-music-server/backend/internal/config"
 	idb "github.com/faraz525/home-music-server/backend/internal/db"
@@ -67,6 +68,16 @@ func main() {
 	)
 	fmt.Printf("[CrateDrop] SoundCloud sync manager initialized\n")
 
+	// Initialize analysis (BPM + key detection)
+	analysisRepo := analysis.NewRepository(db.DB)
+	analyzer := analysis.NewAnalyzer(90 * time.Second)
+	analysisManager := analysis.NewManager(analysisRepo, analyzer)
+	if analysis.BinaryAvailable() {
+		fmt.Printf("[CrateDrop] Analysis worker enabled (essentia binary found)\n")
+	} else {
+		fmt.Printf("[CrateDrop] WARNING: streaming_extractor_music not on PATH — analysis disabled\n")
+	}
+
 	// Initialize router and API group
 	r, api := server.NewRouter()
 
@@ -81,6 +92,10 @@ func main() {
 	// Start SoundCloud sync loop in background
 	ctx := context.Background()
 	go soundcloud.StartSyncLoop(ctx, soundcloudManager)
+
+	if analysis.BinaryAvailable() {
+		go analysis.StartLoop(ctx, analysisManager, 10*time.Second)
+	}
 
 	addr := "0.0.0.0:" + cfg.Port
 	fmt.Printf("[CrateDrop] Server listening on http://%s\n", addr)

--- a/backend/playlists/repository.go
+++ b/backend/playlists/repository.go
@@ -441,7 +441,9 @@ func (r *Repository) GetPlaylistTracks(playlistID string, limit, offset int) (*i
 	query := `
 		SELECT t.id, t.owner_user_id, t.original_filename, t.content_type, t.size_bytes,
 		       t.duration_seconds, t.title, t.artist, t.album, t.genre, t.year,
-		       t.sample_rate, t.bitrate, t.file_path, t.created_at, t.updated_at,
+		       t.sample_rate, t.bitrate,
+		       t.bpm, t.bpm_confidence, t.musical_key, t.key_confidence, t.analyzed_at, t.analysis_status,
+		       t.file_path, t.created_at, t.updated_at,
 		       pt.added_at
 		FROM tracks t
 		INNER JOIN playlist_tracks pt ON t.id = pt.track_id
@@ -459,6 +461,9 @@ func (r *Repository) GetPlaylistTracks(playlistID string, limit, offset int) (*i
 	var tracks []*imodels.Track
 	for rows.Next() {
 		var track imodels.Track
+		var bpm, bpmConf, keyConf sql.NullFloat64
+		var musicalKey sql.NullString
+		var analyzedAt sql.NullTime
 		err := rows.Scan(
 			&track.ID,
 			&track.OwnerUserID,
@@ -473,6 +478,12 @@ func (r *Repository) GetPlaylistTracks(playlistID string, limit, offset int) (*i
 			&track.Year,
 			&track.SampleRate,
 			&track.Bitrate,
+			&bpm,
+			&bpmConf,
+			&musicalKey,
+			&keyConf,
+			&analyzedAt,
+			&track.AnalysisStatus,
 			&track.FilePath,
 			&track.CreatedAt,
 			&track.UpdatedAt,
@@ -480,6 +491,22 @@ func (r *Repository) GetPlaylistTracks(playlistID string, limit, offset int) (*i
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan track: %w", err)
+		}
+		if bpm.Valid {
+			track.BPM = &bpm.Float64
+		}
+		if bpmConf.Valid {
+			track.BPMConfidence = &bpmConf.Float64
+		}
+		if musicalKey.Valid {
+			v := musicalKey.String
+			track.MusicalKey = &v
+		}
+		if keyConf.Valid {
+			track.KeyConfidence = &keyConf.Float64
+		}
+		if analyzedAt.Valid {
+			track.AnalyzedAt = &analyzedAt.Time
 		}
 
 		tracks = append(tracks, &track)
@@ -511,7 +538,9 @@ func (r *Repository) GetTracksNotInPlaylist(userID string, limit, offset int) (*
 	query := `
 		SELECT t.id, t.owner_user_id, t.original_filename, t.content_type, t.size_bytes,
 		       t.duration_seconds, t.title, t.artist, t.album, t.genre, t.year,
-		       t.sample_rate, t.bitrate, t.file_path, t.created_at, t.updated_at
+		       t.sample_rate, t.bitrate,
+		       t.bpm, t.bpm_confidence, t.musical_key, t.key_confidence, t.analyzed_at, t.analysis_status,
+		       t.file_path, t.created_at, t.updated_at
 		FROM tracks t
 		LEFT JOIN playlist_tracks pt ON t.id = pt.track_id
 		WHERE t.owner_user_id = ?
@@ -530,6 +559,9 @@ func (r *Repository) GetTracksNotInPlaylist(userID string, limit, offset int) (*
 	var tracks []*imodels.Track
 	for rows.Next() {
 		var track imodels.Track
+		var bpm, bpmConf, keyConf sql.NullFloat64
+		var musicalKey sql.NullString
+		var analyzedAt sql.NullTime
 		err := rows.Scan(
 			&track.ID,
 			&track.OwnerUserID,
@@ -544,12 +576,34 @@ func (r *Repository) GetTracksNotInPlaylist(userID string, limit, offset int) (*
 			&track.Year,
 			&track.SampleRate,
 			&track.Bitrate,
+			&bpm,
+			&bpmConf,
+			&musicalKey,
+			&keyConf,
+			&analyzedAt,
+			&track.AnalysisStatus,
 			&track.FilePath,
 			&track.CreatedAt,
 			&track.UpdatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan track: %w", err)
+		}
+		if bpm.Valid {
+			track.BPM = &bpm.Float64
+		}
+		if bpmConf.Valid {
+			track.BPMConfidence = &bpmConf.Float64
+		}
+		if musicalKey.Valid {
+			v := musicalKey.String
+			track.MusicalKey = &v
+		}
+		if keyConf.Valid {
+			track.KeyConfidence = &keyConf.Float64
+		}
+		if analyzedAt.Valid {
+			track.AnalyzedAt = &analyzedAt.Time
 		}
 
 		tracks = append(tracks, &track)
@@ -594,7 +648,9 @@ func (r *Repository) SearchTracksNotInPlaylist(userID, query string, limit, offs
 	searchQuery := `
 		SELECT DISTINCT t.id, t.owner_user_id, t.original_filename, t.content_type, t.size_bytes,
 		       t.duration_seconds, t.title, t.artist, t.album, t.genre, t.year,
-		       t.sample_rate, t.bitrate, t.file_path, t.created_at, t.updated_at
+		       t.sample_rate, t.bitrate,
+		       t.bpm, t.bpm_confidence, t.musical_key, t.key_confidence, t.analyzed_at, t.analysis_status,
+		       t.file_path, t.created_at, t.updated_at
 		FROM tracks t
 		INNER JOIN tracks_fts fts ON t.id = fts.track_id
 		LEFT JOIN playlist_tracks pt ON t.id = pt.track_id
@@ -614,6 +670,9 @@ func (r *Repository) SearchTracksNotInPlaylist(userID, query string, limit, offs
 	var tracks []*imodels.Track
 	for rows.Next() {
 		var track imodels.Track
+		var bpm, bpmConf, keyConf sql.NullFloat64
+		var musicalKey sql.NullString
+		var analyzedAt sql.NullTime
 		err := rows.Scan(
 			&track.ID,
 			&track.OwnerUserID,
@@ -628,12 +687,34 @@ func (r *Repository) SearchTracksNotInPlaylist(userID, query string, limit, offs
 			&track.Year,
 			&track.SampleRate,
 			&track.Bitrate,
+			&bpm,
+			&bpmConf,
+			&musicalKey,
+			&keyConf,
+			&analyzedAt,
+			&track.AnalysisStatus,
 			&track.FilePath,
 			&track.CreatedAt,
 			&track.UpdatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan track: %w", err)
+		}
+		if bpm.Valid {
+			track.BPM = &bpm.Float64
+		}
+		if bpmConf.Valid {
+			track.BPMConfidence = &bpmConf.Float64
+		}
+		if musicalKey.Valid {
+			v := musicalKey.String
+			track.MusicalKey = &v
+		}
+		if keyConf.Valid {
+			track.KeyConfidence = &keyConf.Float64
+		}
+		if analyzedAt.Valid {
+			track.AnalyzedAt = &analyzedAt.Time
 		}
 
 		tracks = append(tracks, &track)
@@ -671,7 +752,9 @@ func (r *Repository) SearchPlaylistTracks(playlistID, query string, limit, offse
 	searchQuery := `
 		SELECT t.id, t.owner_user_id, t.original_filename, t.content_type, t.size_bytes,
 		       t.duration_seconds, t.title, t.artist, t.album, t.genre, t.year,
-		       t.sample_rate, t.bitrate, t.file_path, t.created_at, t.updated_at
+		       t.sample_rate, t.bitrate,
+		       t.bpm, t.bpm_confidence, t.musical_key, t.key_confidence, t.analyzed_at, t.analysis_status,
+		       t.file_path, t.created_at, t.updated_at
 		FROM tracks t
 		INNER JOIN tracks_fts fts ON t.id = fts.track_id
 		INNER JOIN playlist_tracks pt ON t.id = pt.track_id
@@ -690,6 +773,9 @@ func (r *Repository) SearchPlaylistTracks(playlistID, query string, limit, offse
 	var tracks []*imodels.Track
 	for rows.Next() {
 		var track imodels.Track
+		var bpm, bpmConf, keyConf sql.NullFloat64
+		var musicalKey sql.NullString
+		var analyzedAt sql.NullTime
 		err := rows.Scan(
 			&track.ID,
 			&track.OwnerUserID,
@@ -704,12 +790,34 @@ func (r *Repository) SearchPlaylistTracks(playlistID, query string, limit, offse
 			&track.Year,
 			&track.SampleRate,
 			&track.Bitrate,
+			&bpm,
+			&bpmConf,
+			&musicalKey,
+			&keyConf,
+			&analyzedAt,
+			&track.AnalysisStatus,
 			&track.FilePath,
 			&track.CreatedAt,
 			&track.UpdatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan track: %w", err)
+		}
+		if bpm.Valid {
+			track.BPM = &bpm.Float64
+		}
+		if bpmConf.Valid {
+			track.BPMConfidence = &bpmConf.Float64
+		}
+		if musicalKey.Valid {
+			v := musicalKey.String
+			track.MusicalKey = &v
+		}
+		if keyConf.Valid {
+			track.KeyConfidence = &keyConf.Float64
+		}
+		if analyzedAt.Valid {
+			track.AnalyzedAt = &analyzedAt.Time
 		}
 
 		tracks = append(tracks, &track)

--- a/backend/tracks/patch_handler.go
+++ b/backend/tracks/patch_handler.go
@@ -1,8 +1,10 @@
 package tracks
 
 import (
+	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -12,10 +14,18 @@ type patchTrackRequest struct {
 	MusicalKey *string  `json:"musical_key,omitempty"`
 }
 
+// BPM bounds: 50 covers slow ballads / downtempo; 250 covers drum & bass /
+// hardcore. Tracks outside this range exist but are vanishingly rare in DJ
+// libraries and usually indicate a half-time / double-time analysis error.
+const (
+	minBPM = 50
+	maxBPM = 250
+)
+
 var camelotRE = regexp.MustCompile(`^(1[0-2]|[1-9])[AB]$`)
 
 func isValidBPM(bpm float64) bool {
-	return bpm >= 50 && bpm <= 250
+	return bpm >= minBPM && bpm <= maxBPM
 }
 
 func isValidCamelot(k string) bool {
@@ -23,12 +33,12 @@ func isValidCamelot(k string) bool {
 }
 
 // PatchHandler handles PATCH /api/tracks/:id for user overrides of BPM/key.
-// `mgr` can be nil only in tests that exercise validation paths.
+// `mgr` can be nil only in tests that exercise validation-only paths.
 func PatchHandler(mgr *Manager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req patchTrackRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_body", "message": err.Error()}})
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_body", "message": "request body is not valid JSON"}})
 			return
 		}
 		if req.BPM == nil && req.MusicalKey == nil {
@@ -36,12 +46,17 @@ func PatchHandler(mgr *Manager) gin.HandlerFunc {
 			return
 		}
 		if req.BPM != nil && !isValidBPM(*req.BPM) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_bpm", "message": "bpm must be between 50 and 250"}})
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_bpm", "message": fmt.Sprintf("bpm must be between %d and %d", minBPM, maxBPM)}})
 			return
 		}
-		if req.MusicalKey != nil && !isValidCamelot(*req.MusicalKey) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_key", "message": "musical_key must be Camelot notation like 8A or 12B"}})
-			return
+		if req.MusicalKey != nil {
+			// Normalize to uppercase (DJs routinely type "8a"); validate after.
+			upper := strings.ToUpper(*req.MusicalKey)
+			req.MusicalKey = &upper
+			if !isValidCamelot(*req.MusicalKey) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_key", "message": "musical_key must be Camelot notation like 8A or 12B"}})
+				return
+			}
 		}
 
 		trackID := c.Param("id")
@@ -52,23 +67,31 @@ func PatchHandler(mgr *Manager) gin.HandlerFunc {
 
 		userIDAny, _ := c.Get("user_id")
 		userID, _ := userIDAny.(string)
+		userRoleAny, _ := c.Get("user_role")
+		userRole, _ := userRoleAny.(string)
+
 		track, err := mgr.GetTrack(c.Request.Context(), trackID)
 		if err != nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "not_found", "message": "track not found"}})
 			return
 		}
-		if track.OwnerUserID != userID {
+		// Match the owner-or-admin pattern used by sibling handlers
+		// (GetHandler, StreamHandler, DeleteHandler).
+		if track.OwnerUserID != userID && userRole != "admin" {
 			c.JSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "forbidden", "message": "not your track"}})
 			return
 		}
 
 		if err := mgr.UpdateAnalysisOverride(c.Request.Context(), trackID, req.BPM, req.MusicalKey); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "update_failed", "message": err.Error()}})
+			// Don't leak SQL driver text to clients.
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "update_failed", "message": "failed to update track analysis"}})
 			return
 		}
 		updated, err := mgr.GetTrack(c.Request.Context(), trackID)
 		if err != nil {
-			c.Status(http.StatusNoContent)
+			// Update succeeded; re-fetch failed. Report success — the client
+			// can refresh if it needs the canonical row.
+			c.JSON(http.StatusOK, gin.H{"success": true})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"success": true, "data": updated})

--- a/backend/tracks/patch_handler.go
+++ b/backend/tracks/patch_handler.go
@@ -1,0 +1,76 @@
+package tracks
+
+import (
+	"net/http"
+	"regexp"
+
+	"github.com/gin-gonic/gin"
+)
+
+type patchTrackRequest struct {
+	BPM        *float64 `json:"bpm,omitempty"`
+	MusicalKey *string  `json:"musical_key,omitempty"`
+}
+
+var camelotRE = regexp.MustCompile(`^(1[0-2]|[1-9])[AB]$`)
+
+func isValidBPM(bpm float64) bool {
+	return bpm >= 50 && bpm <= 250
+}
+
+func isValidCamelot(k string) bool {
+	return camelotRE.MatchString(k)
+}
+
+// PatchHandler handles PATCH /api/tracks/:id for user overrides of BPM/key.
+// `mgr` can be nil only in tests that exercise validation paths.
+func PatchHandler(mgr *Manager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req patchTrackRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_body", "message": err.Error()}})
+			return
+		}
+		if req.BPM == nil && req.MusicalKey == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "empty_patch", "message": "at least one of bpm, musical_key is required"}})
+			return
+		}
+		if req.BPM != nil && !isValidBPM(*req.BPM) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_bpm", "message": "bpm must be between 50 and 250"}})
+			return
+		}
+		if req.MusicalKey != nil && !isValidCamelot(*req.MusicalKey) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_key", "message": "musical_key must be Camelot notation like 8A or 12B"}})
+			return
+		}
+
+		trackID := c.Param("id")
+		if mgr == nil {
+			c.Status(http.StatusNoContent)
+			return
+		}
+
+		userIDAny, _ := c.Get("user_id")
+		userID, _ := userIDAny.(string)
+		track, err := mgr.GetTrack(c.Request.Context(), trackID)
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "not_found", "message": "track not found"}})
+			return
+		}
+		if track.OwnerUserID != userID {
+			c.JSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "forbidden", "message": "not your track"}})
+			return
+		}
+
+		if err := mgr.UpdateAnalysisOverride(c.Request.Context(), trackID, req.BPM, req.MusicalKey); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "update_failed", "message": err.Error()}})
+			return
+		}
+		updated, err := mgr.GetTrack(c.Request.Context(), trackID)
+		if err != nil {
+			c.Status(http.StatusNoContent)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": updated})
+	}
+}

--- a/backend/tracks/patch_handler_test.go
+++ b/backend/tracks/patch_handler_test.go
@@ -1,0 +1,69 @@
+package tracks
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestValidateKey(t *testing.T) {
+	valid := []string{"1A", "12B", "7A", "9B"}
+	for _, k := range valid {
+		if !isValidCamelot(k) {
+			t.Errorf("isValidCamelot(%q) = false, want true", k)
+		}
+	}
+	invalid := []string{"", "0A", "13A", "1C", "1a", "A1", "100A"}
+	for _, k := range invalid {
+		if isValidCamelot(k) {
+			t.Errorf("isValidCamelot(%q) = true, want false", k)
+		}
+	}
+}
+
+func TestValidateBPM(t *testing.T) {
+	if !isValidBPM(120) {
+		t.Error("isValidBPM(120) = false, want true")
+	}
+	if isValidBPM(49) {
+		t.Error("isValidBPM(49) = true, want false")
+	}
+	if isValidBPM(251) {
+		t.Error("isValidBPM(251) = true, want false")
+	}
+}
+
+// TestPatchHandler_RejectsInvalidBody verifies the handler rejects malformed
+// payloads with a 400 response. Uses a nil manager since we don't reach the
+// DB for validation-only tests.
+func TestPatchHandler_RejectsInvalidBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.PATCH("/api/tracks/:id", PatchHandler(nil))
+
+	req := httptest.NewRequest("PATCH", "/api/tracks/abc", strings.NewReader(`{"bpm": 9999}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestPatchHandler_RejectsEmptyBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.PATCH("/api/tracks/:id", PatchHandler(nil))
+
+	req := httptest.NewRequest("PATCH", "/api/tracks/abc", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Errorf("status = %d, want 400 (empty body)", w.Code)
+	}
+}

--- a/backend/tracks/routes.go
+++ b/backend/tracks/routes.go
@@ -16,6 +16,7 @@ func Routes(m *Manager, pm *playlists.Manager) func(*gin.RouterGroup) {
 		g.GET("/:id/download", DownloadHandler(m))
 		g.DELETE("/:id", DeleteHandler(m))
 		g.GET("/:id", GetHandler(m))
+		g.PATCH("/:id", PatchHandler(m))
 
 	// Admin routes
 	admin := g.Group("/admin")

--- a/backend/tracks/tracksdata.go
+++ b/backend/tracks/tracksdata.go
@@ -312,3 +312,23 @@ func prepareFTS5Query(query string) string {
 	// "on & on" becomes "on* AND on*" (& is removed, both "on" terms must match)
 	return strings.Join(terms, " AND ")
 }
+
+// UpdateAnalysisOverride sets user-edited BPM and/or key and flips status to 'user_edited'.
+// nil values leave the corresponding column untouched.
+func (r *Repository) UpdateAnalysisOverride(ctx context.Context, trackID string, bpm *float64, musicalKey *string) error {
+	// Build a dynamic SET clause so we only update provided fields.
+	sets := []string{"analysis_status = 'user_edited'", "analysis_error = NULL", "next_retry_at = NULL", "updated_at = CURRENT_TIMESTAMP"}
+	args := []any{}
+	if bpm != nil {
+		sets = append(sets, "bpm = ?")
+		args = append(args, *bpm)
+	}
+	if musicalKey != nil {
+		sets = append(sets, "musical_key = ?")
+		args = append(args, *musicalKey)
+	}
+	args = append(args, trackID)
+	query := "UPDATE tracks SET " + strings.Join(sets, ", ") + " WHERE id = ?"
+	_, err := r.db.ExecContext(ctx, query, args...)
+	return err
+}

--- a/backend/tracks/tracksdata.go
+++ b/backend/tracks/tracksdata.go
@@ -2,6 +2,7 @@ package tracks
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 
 	"github.com/faraz525/home-music-server/backend/internal/db"
@@ -17,6 +18,74 @@ type Repository struct {
 // NewRepository creates a new tracks data
 func NewRepository(db *db.DB) *Repository {
 	return &Repository{db: db}
+}
+
+// scanTrack scans a row into a Track, handling nullable columns.
+// Accepts either *sql.Row or *sql.Rows via the Scan method.
+func scanTrack(row interface{ Scan(dest ...any) error }) (*imodels.Track, error) {
+	var t imodels.Track
+	var duration, bpm, bpmConf, keyConf sql.NullFloat64
+	var title, artist, album, genre, key sql.NullString
+	var year, sampleRate, bitrate sql.NullInt64
+	var analyzedAt sql.NullTime
+
+	err := row.Scan(
+		&t.ID, &t.OwnerUserID, &t.OriginalFilename, &t.ContentType, &t.SizeBytes,
+		&duration, &title, &artist, &album, &genre, &year, &sampleRate, &bitrate,
+		&bpm, &bpmConf, &key, &keyConf, &analyzedAt, &t.AnalysisStatus,
+		&t.FilePath, &t.CreatedAt, &t.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if duration.Valid {
+		t.DurationSeconds = &duration.Float64
+	}
+	if title.Valid {
+		v := title.String
+		t.Title = &v
+	}
+	if artist.Valid {
+		v := artist.String
+		t.Artist = &v
+	}
+	if album.Valid {
+		v := album.String
+		t.Album = &v
+	}
+	if genre.Valid {
+		v := genre.String
+		t.Genre = &v
+	}
+	if year.Valid {
+		v := int(year.Int64)
+		t.Year = &v
+	}
+	if sampleRate.Valid {
+		v := int(sampleRate.Int64)
+		t.SampleRate = &v
+	}
+	if bitrate.Valid {
+		v := int(bitrate.Int64)
+		t.Bitrate = &v
+	}
+	if bpm.Valid {
+		t.BPM = &bpm.Float64
+	}
+	if bpmConf.Valid {
+		t.BPMConfidence = &bpmConf.Float64
+	}
+	if key.Valid {
+		v := key.String
+		t.MusicalKey = &v
+	}
+	if keyConf.Valid {
+		t.KeyConfidence = &keyConf.Float64
+	}
+	if analyzedAt.Valid {
+		t.AnalyzedAt = &analyzedAt.Time
+	}
+	return &t, nil
 }
 
 // CreateTrack creates a new track in the database
@@ -42,7 +111,9 @@ func (r *Repository) CreateTrack(ctx context.Context, track *imodels.Track) (*im
 // GetTracks retrieves tracks for a user with pagination
 func (r *Repository) GetTracks(ctx context.Context, userID string, limit, offset int) ([]*imodels.Track, error) {
 	query := `SELECT id, owner_user_id, original_filename, content_type, size_bytes,
-		duration_seconds, title, artist, album, genre, year, sample_rate, bitrate, file_path, created_at, updated_at
+		duration_seconds, title, artist, album, genre, year, sample_rate, bitrate,
+		bpm, bpm_confidence, musical_key, key_confidence, analyzed_at, analysis_status,
+		file_path, created_at, updated_at
 		FROM tracks WHERE owner_user_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?`
 
 	rows, err := r.db.QueryContext(ctx, query, userID, limit, offset)
@@ -53,16 +124,11 @@ func (r *Repository) GetTracks(ctx context.Context, userID string, limit, offset
 
 	var tracks []*imodels.Track
 	for rows.Next() {
-		var track imodels.Track
-		err := rows.Scan(
-			&track.ID, &track.OwnerUserID, &track.OriginalFilename, &track.ContentType, &track.SizeBytes,
-			&track.DurationSeconds, &track.Title, &track.Artist, &track.Album, &track.Genre, &track.Year,
-			&track.SampleRate, &track.Bitrate, &track.FilePath, &track.CreatedAt, &track.UpdatedAt,
-		)
+		track, err := scanTrack(rows)
 		if err != nil {
 			return nil, err
 		}
-		tracks = append(tracks, &track)
+		tracks = append(tracks, track)
 	}
 
 	return tracks, rows.Err()
@@ -77,8 +143,10 @@ func (r *Repository) GetAllTracks(ctx context.Context, limit, offset int, search
 		// Use FTS5 for search
 		query = `
 			SELECT t.id, t.owner_user_id, t.original_filename, t.content_type, t.size_bytes,
-				t.duration_seconds, t.title, t.artist, t.album, t.genre, t.year, 
-				t.sample_rate, t.bitrate, t.file_path, t.created_at, t.updated_at
+				t.duration_seconds, t.title, t.artist, t.album, t.genre, t.year,
+				t.sample_rate, t.bitrate,
+				t.bpm, t.bpm_confidence, t.musical_key, t.key_confidence, t.analyzed_at, t.analysis_status,
+				t.file_path, t.created_at, t.updated_at
 			FROM tracks t
 			INNER JOIN tracks_fts fts ON t.id = fts.track_id
 			WHERE tracks_fts MATCH ?
@@ -91,10 +159,11 @@ func (r *Repository) GetAllTracks(ctx context.Context, limit, offset int, search
 		// No search, just list all
 		query = `
 			SELECT id, owner_user_id, original_filename, content_type, size_bytes,
-				duration_seconds, title, artist, album, genre, year, sample_rate, bitrate, 
+				duration_seconds, title, artist, album, genre, year, sample_rate, bitrate,
+				bpm, bpm_confidence, musical_key, key_confidence, analyzed_at, analysis_status,
 				file_path, created_at, updated_at
-			FROM tracks 
-			ORDER BY created_at DESC 
+			FROM tracks
+			ORDER BY created_at DESC
 			LIMIT ? OFFSET ?
 		`
 		args = []interface{}{limit, offset}
@@ -108,16 +177,11 @@ func (r *Repository) GetAllTracks(ctx context.Context, limit, offset int, search
 
 	var tracks []*imodels.Track
 	for rows.Next() {
-		var track imodels.Track
-		err := rows.Scan(
-			&track.ID, &track.OwnerUserID, &track.OriginalFilename, &track.ContentType, &track.SizeBytes,
-			&track.DurationSeconds, &track.Title, &track.Artist, &track.Album, &track.Genre, &track.Year,
-			&track.SampleRate, &track.Bitrate, &track.FilePath, &track.CreatedAt, &track.UpdatedAt,
-		)
+		track, err := scanTrack(rows)
 		if err != nil {
 			return nil, err
 		}
-		tracks = append(tracks, &track)
+		tracks = append(tracks, track)
 	}
 
 	return tracks, rows.Err()
@@ -125,21 +189,15 @@ func (r *Repository) GetAllTracks(ctx context.Context, limit, offset int, search
 
 // GetTrackByID retrieves a single track by ID
 func (r *Repository) GetTrackByID(ctx context.Context, trackID string) (*imodels.Track, error) {
-	var track imodels.Track
-	err := r.db.QueryRowContext(ctx,
+	row := r.db.QueryRowContext(ctx,
 		`SELECT id, owner_user_id, original_filename, content_type, size_bytes,
-		duration_seconds, title, artist, album, genre, year, sample_rate, bitrate, file_path, created_at, updated_at
+		duration_seconds, title, artist, album, genre, year, sample_rate, bitrate,
+		bpm, bpm_confidence, musical_key, key_confidence, analyzed_at, analysis_status,
+		file_path, created_at, updated_at
 		FROM tracks WHERE id = ?`,
 		trackID,
-	).Scan(
-		&track.ID, &track.OwnerUserID, &track.OriginalFilename, &track.ContentType, &track.SizeBytes,
-		&track.DurationSeconds, &track.Title, &track.Artist, &track.Album, &track.Genre, &track.Year,
-		&track.SampleRate, &track.Bitrate, &track.FilePath, &track.CreatedAt, &track.UpdatedAt,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return &track, nil
+	return scanTrack(row)
 }
 
 // DeleteTrack deletes a track by ID
@@ -169,11 +227,13 @@ func (r *Repository) SearchTracks(ctx context.Context, query string, userID stri
 	// Use double quotes for phrase matching or just the term for any word matching
 	searchQuery := `
 		SELECT t.id, t.owner_user_id, t.original_filename, t.content_type, t.size_bytes,
-			t.duration_seconds, t.title, t.artist, t.album, t.genre, t.year, 
-			t.sample_rate, t.bitrate, t.file_path, t.created_at, t.updated_at
+			t.duration_seconds, t.title, t.artist, t.album, t.genre, t.year,
+			t.sample_rate, t.bitrate,
+			t.bpm, t.bpm_confidence, t.musical_key, t.key_confidence, t.analyzed_at, t.analysis_status,
+			t.file_path, t.created_at, t.updated_at
 		FROM tracks t
 		INNER JOIN tracks_fts fts ON t.id = fts.track_id
-		WHERE t.owner_user_id = ? 
+		WHERE t.owner_user_id = ?
 		AND tracks_fts MATCH ?
 		ORDER BY fts.rank, t.created_at DESC
 		LIMIT ? OFFSET ?
@@ -199,16 +259,11 @@ func (r *Repository) SearchTracks(ctx context.Context, query string, userID stri
 
 	var tracks []*imodels.Track
 	for rows.Next() {
-		var track imodels.Track
-		err := rows.Scan(
-			&track.ID, &track.OwnerUserID, &track.OriginalFilename, &track.ContentType, &track.SizeBytes,
-			&track.DurationSeconds, &track.Title, &track.Artist, &track.Album, &track.Genre, &track.Year,
-			&track.SampleRate, &track.Bitrate, &track.FilePath, &track.CreatedAt, &track.UpdatedAt,
-		)
+		track, err := scanTrack(rows)
 		if err != nil {
 			return nil, err
 		}
-		tracks = append(tracks, &track)
+		tracks = append(tracks, track)
 	}
 
 	return tracks, rows.Err()

--- a/backend/tracks/tracksmanager.go
+++ b/backend/tracks/tracksmanager.go
@@ -380,3 +380,9 @@ func derefInt(p *int) int {
 	}
 	return *p
 }
+
+// UpdateAnalysisOverride applies a user override to BPM and/or musical key.
+// Caller has already validated ranges and authorized the request.
+func (m *Manager) UpdateAnalysisOverride(ctx context.Context, trackID string, bpm *float64, musicalKey *string) error {
+	return m.repo.UpdateAnalysisOverride(ctx, trackID, bpm, musicalKey)
+}

--- a/docs/superpowers/plans/2026-04-16-bpm-key-analysis.md
+++ b/docs/superpowers/plans/2026-04-16-bpm-key-analysis.md
@@ -1,0 +1,2284 @@
+# BPM & Musical Key Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every track in the library gets auto-detected BPM and musical key (Camelot notation), displayed in the track list as sortable columns, inline-editable with confidence indicators.
+
+**Architecture:** A new `backend/analysis/` Go package running an in-process goroutine that polls SQLite every 10s for `pending` tracks, shells out to essentia's `streaming_extractor_music`, parses JSON output, and writes BPM + Camelot key back. Failed analyses retry with exponential backoff (10m, 1h, 6h) before becoming terminal `failed`. User edits set a `user_edited` status the worker respects. Frontend `LibraryPage` gains two new columns (BPM, Key) with confidence dots and inline editing.
+
+**Tech Stack:** Go 1.23 + Gin + SQLite (`mattn/go-sqlite3`), React 18 + Vite + TanStack Query + Tailwind, essentia `streaming_extractor_music` CLI on PATH. Tests use Go's stdlib `testing` package with in-memory SQLite (`:memory:`).
+
+**Spec:** [`docs/superpowers/specs/2026-04-16-bpm-key-analysis-design.md`](../specs/2026-04-16-bpm-key-analysis-design.md)
+
+---
+
+## File Structure
+
+### New files
+- `backend/internal/db/migrations/003_add_track_analysis.sql` — schema changes
+- `backend/analysis/camelot.go` — pure `(key, scale) -> Camelot` mapping
+- `backend/analysis/camelot_test.go`
+- `backend/analysis/essentia.go` — subprocess wrapper
+- `backend/analysis/essentia_test.go`
+- `backend/analysis/essentia_parse.go` — split so the JSON parser is testable without a subprocess
+- `backend/analysis/essentia_parse_test.go`
+- `backend/analysis/testdata/essentia_success.json` — fixture
+- `backend/analysis/repository.go` — DB claim/update helpers
+- `backend/analysis/repository_test.go`
+- `backend/analysis/manager.go` — orchestrates one claim + analyze + write
+- `backend/analysis/manager_test.go`
+- `backend/analysis/ticker.go` — `StartLoop(ctx, *Manager)` background poller
+- `backend/tracks/patch_handler.go` — new `PATCH /api/tracks/:id` handler
+- `backend/tracks/patch_handler_test.go`
+
+### Modified files
+- `backend/internal/db/db.go` — apply migration 003 on boot, detect missing `bpm` column
+- `backend/internal/models/models.go` — extend `Track` struct with new optional fields
+- `backend/tracks/tracksdata.go` — include new columns in all SELECT/INSERT/UPDATE statements
+- `backend/tracks/routes.go` — register PATCH route
+- `backend/tracks/tracksmanager.go` — add `UpdateAnalysis(ctx, trackID, bpm *float64, key *string)` method for user overrides
+- `backend/main.go` — init `analysis.Manager` + `analysis.Repository`, start ticker goroutine
+- `frontend/src/types/crates.ts` — (this file currently holds `TrackList`) extend `Track` type with new fields
+- `frontend/src/pages/LibraryPage.tsx` — add BPM/Key columns and inline editing
+- `frontend/src/lib/api.ts` — add `tracksApi.patch(id, payload)`
+- `frontend/src/hooks/useQueries.ts` — add `useUpdateTrackAnalysis()` mutation
+- `deploy-local.sh`, `deploy-prod.sh` — add `which streaming_extractor_music` verification
+- `README.md` — deploy prereq note
+
+---
+
+## Task 1: DB migration and model extension
+
+**Files:**
+- Create: `backend/internal/db/migrations/003_add_track_analysis.sql`
+- Modify: `backend/internal/db/db.go` (end of `migrate()` function, after the 002 block around line 117)
+- Modify: `backend/internal/models/models.go:15-32` (Track struct)
+
+- [ ] **Step 1: Create the migration file**
+
+Create `backend/internal/db/migrations/003_add_track_analysis.sql`:
+
+```sql
+-- Track analysis fields for BPM + Musical Key detection
+ALTER TABLE tracks ADD COLUMN bpm REAL;
+ALTER TABLE tracks ADD COLUMN bpm_confidence REAL;
+ALTER TABLE tracks ADD COLUMN musical_key TEXT;              -- Camelot notation, e.g. "8A"
+ALTER TABLE tracks ADD COLUMN key_confidence REAL;
+ALTER TABLE tracks ADD COLUMN analyzed_at DATETIME;
+ALTER TABLE tracks ADD COLUMN analysis_status TEXT NOT NULL DEFAULT 'pending';
+ALTER TABLE tracks ADD COLUMN analysis_error TEXT;
+ALTER TABLE tracks ADD COLUMN analysis_retry_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE tracks ADD COLUMN next_retry_at DATETIME;
+
+CREATE INDEX IF NOT EXISTS idx_tracks_analysis_status
+    ON tracks(analysis_status, next_retry_at);
+```
+
+Also append the same columns to `backend/internal/db/migrations/schema.sql` inside the `CREATE TABLE tracks (...)` block (between `bitrate INTEGER,` and `file_path TEXT NOT NULL,`) so fresh DBs include them. The matching index addition goes at the end of the tracks-related section:
+
+```sql
+    bitrate INTEGER,
+    bpm REAL,
+    bpm_confidence REAL,
+    musical_key TEXT,
+    key_confidence REAL,
+    analyzed_at DATETIME,
+    analysis_status TEXT NOT NULL DEFAULT 'pending',
+    analysis_error TEXT,
+    analysis_retry_count INTEGER NOT NULL DEFAULT 0,
+    next_retry_at DATETIME,
+    file_path TEXT NOT NULL,
+```
+
+And add this index near the other track indexes:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_tracks_analysis_status
+    ON tracks(analysis_status, next_retry_at);
+```
+
+- [ ] **Step 2: Wire the migration into `db.go`**
+
+At the end of `migrate()` in `backend/internal/db/db.go` (before the final `return nil`), add:
+
+```go
+// Check if bpm column exists on tracks table
+var bpmColCount int
+_ = d.QueryRow(`
+    SELECT COUNT(*)
+    FROM pragma_table_info('tracks')
+    WHERE name='bpm'
+`).Scan(&bpmColCount)
+if bpmColCount == 0 {
+    migrationSQL, err := migrationsFS.ReadFile("migrations/003_add_track_analysis.sql")
+    if err != nil {
+        return fmt.Errorf("failed to read migration 003_add_track_analysis: %w", err)
+    }
+    if _, err := d.Exec(string(migrationSQL)); err != nil {
+        return fmt.Errorf("failed to execute migration 003_add_track_analysis: %w", err)
+    }
+}
+```
+
+- [ ] **Step 3: Extend the Track model**
+
+In `backend/internal/models/models.go`, replace the `Track` struct with:
+
+```go
+type Track struct {
+    ID                 string     `json:"id"`
+    OwnerUserID        string     `json:"owner_user_id"`
+    OriginalFilename   string     `json:"original_filename"`
+    ContentType        string     `json:"content_type"`
+    SizeBytes          int64      `json:"size_bytes"`
+    DurationSeconds    *float64   `json:"duration_seconds,omitempty"`
+    Title              *string    `json:"title,omitempty"`
+    Artist             *string    `json:"artist,omitempty"`
+    Album              *string    `json:"album,omitempty"`
+    Genre              *string    `json:"genre,omitempty"`
+    Year               *int       `json:"year,omitempty"`
+    SampleRate         *int       `json:"sample_rate,omitempty"`
+    Bitrate            *int       `json:"bitrate,omitempty"`
+    BPM                *float64   `json:"bpm,omitempty"`
+    BPMConfidence      *float64   `json:"bpm_confidence,omitempty"`
+    MusicalKey         *string    `json:"musical_key,omitempty"`
+    KeyConfidence      *float64   `json:"key_confidence,omitempty"`
+    AnalyzedAt         *time.Time `json:"analyzed_at,omitempty"`
+    AnalysisStatus     string     `json:"analysis_status"`
+    FilePath           string     `json:"file_path"`
+    CreatedAt          time.Time  `json:"created_at"`
+    UpdatedAt          time.Time  `json:"updated_at"`
+}
+```
+
+Note `AnalysisStatus` is non-pointer `string` because the migration default ensures it's always present. We do NOT expose `analysis_error`, `analysis_retry_count`, or `next_retry_at` via JSON — internal only.
+
+- [ ] **Step 4: Update the tracks repository to read/write new columns**
+
+In `backend/tracks/tracksdata.go`, every SELECT and INSERT involving `tracks` must include the new columns. For each `SELECT id, owner_user_id, original_filename, content_type, size_bytes, duration_seconds, title, artist, album, genre, year, sample_rate, bitrate, file_path, created_at, updated_at FROM tracks ...` replace with:
+
+```sql
+SELECT id, owner_user_id, original_filename, content_type, size_bytes,
+    duration_seconds, title, artist, album, genre, year, sample_rate, bitrate,
+    bpm, bpm_confidence, musical_key, key_confidence, analyzed_at, analysis_status,
+    file_path, created_at, updated_at
+FROM tracks ...
+```
+
+In `CreateTrack`, leave the INSERT column list alone — the new columns default via the migration. But the row scans must be extended. Add helper scan logic at the top of the file (or wherever scan is done):
+
+```go
+func scanTrack(row interface{ Scan(dest ...any) error }) (*imodels.Track, error) {
+    var t imodels.Track
+    var duration, bpm, bpmConf, keyConf sql.NullFloat64
+    var title, artist, album, genre, key sql.NullString
+    var year, sampleRate, bitrate sql.NullInt64
+    var analyzedAt sql.NullTime
+
+    err := row.Scan(
+        &t.ID, &t.OwnerUserID, &t.OriginalFilename, &t.ContentType, &t.SizeBytes,
+        &duration, &title, &artist, &album, &genre, &year, &sampleRate, &bitrate,
+        &bpm, &bpmConf, &key, &keyConf, &analyzedAt, &t.AnalysisStatus,
+        &t.FilePath, &t.CreatedAt, &t.UpdatedAt,
+    )
+    if err != nil {
+        return nil, err
+    }
+    if duration.Valid {
+        t.DurationSeconds = &duration.Float64
+    }
+    if title.Valid {
+        v := title.String; t.Title = &v
+    }
+    if artist.Valid {
+        v := artist.String; t.Artist = &v
+    }
+    if album.Valid {
+        v := album.String; t.Album = &v
+    }
+    if genre.Valid {
+        v := genre.String; t.Genre = &v
+    }
+    if year.Valid {
+        v := int(year.Int64); t.Year = &v
+    }
+    if sampleRate.Valid {
+        v := int(sampleRate.Int64); t.SampleRate = &v
+    }
+    if bitrate.Valid {
+        v := int(bitrate.Int64); t.Bitrate = &v
+    }
+    if bpm.Valid {
+        t.BPM = &bpm.Float64
+    }
+    if bpmConf.Valid {
+        t.BPMConfidence = &bpmConf.Float64
+    }
+    if key.Valid {
+        v := key.String; t.MusicalKey = &v
+    }
+    if keyConf.Valid {
+        t.KeyConfidence = &keyConf.Float64
+    }
+    if analyzedAt.Valid {
+        t.AnalyzedAt = &analyzedAt.Time
+    }
+    return &t, nil
+}
+```
+
+Replace existing scan loops (`GetTracks`, `GetAllTracks`, `GetTrackByID`, etc.) to use this helper and the extended SELECT. Add `import "database/sql"` if not present.
+
+- [ ] **Step 5: Build and run**
+
+Run from `backend/`:
+
+```bash
+go build ./...
+```
+
+Expected: clean build with no errors.
+
+Start the server against a scratch data dir and verify the migration applies:
+
+```bash
+rm -rf /tmp/cratedrop-test-data
+DATA_DIR=/tmp/cratedrop-test-data PORT=8081 go run . &
+SERVER_PID=$!
+sleep 2
+sqlite3 /tmp/cratedrop-test-data/db/cratedrop.sqlite "PRAGMA table_info(tracks);" | grep -E "bpm|musical_key|analysis_status"
+kill $SERVER_PID
+```
+
+Expected output shows `bpm`, `bpm_confidence`, `musical_key`, `key_confidence`, `analyzed_at`, `analysis_status`, `analysis_error`, `analysis_retry_count`, `next_retry_at`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/internal/db/migrations/003_add_track_analysis.sql \
+        backend/internal/db/migrations/schema.sql \
+        backend/internal/db/db.go \
+        backend/internal/models/models.go \
+        backend/tracks/tracksdata.go
+git commit -m "feat: add track analysis columns (bpm, key, status) to schema"
+```
+
+---
+
+## Task 2: Camelot key mapping (pure function, TDD)
+
+**Files:**
+- Create: `backend/analysis/camelot.go`
+- Create: `backend/analysis/camelot_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/analysis/camelot_test.go`:
+
+```go
+package analysis
+
+import "testing"
+
+func TestToCamelot(t *testing.T) {
+    cases := []struct {
+        key, scale, want string
+    }{
+        // Major -> B side
+        {"C", "major", "8B"},
+        {"G", "major", "9B"},
+        {"D", "major", "10B"},
+        {"A", "major", "11B"},
+        {"E", "major", "12B"},
+        {"B", "major", "1B"},
+        {"F#", "major", "2B"},
+        {"Db", "major", "3B"},
+        {"Ab", "major", "4B"},
+        {"Eb", "major", "5B"},
+        {"Bb", "major", "6B"},
+        {"F", "major", "7B"},
+        // Minor -> A side
+        {"A", "minor", "8A"},
+        {"E", "minor", "9A"},
+        {"B", "minor", "10A"},
+        {"F#", "minor", "11A"},
+        {"C#", "minor", "12A"},
+        {"G#", "minor", "1A"},
+        {"Eb", "minor", "2A"},
+        {"Bb", "minor", "3A"},
+        {"F", "minor", "4A"},
+        {"C", "minor", "5A"},
+        {"G", "minor", "6A"},
+        {"D", "minor", "7A"},
+        // Enharmonic equivalents accepted
+        {"Gb", "major", "2B"}, // same as F#
+        {"C#", "major", "3B"}, // same as Db
+        {"D#", "minor", "2A"}, // same as Eb
+    }
+    for _, tc := range cases {
+        got := ToCamelot(tc.key, tc.scale)
+        if got != tc.want {
+            t.Errorf("ToCamelot(%q, %q) = %q, want %q", tc.key, tc.scale, got, tc.want)
+        }
+    }
+}
+
+func TestToCamelot_Invalid(t *testing.T) {
+    cases := []struct{ key, scale string }{
+        {"", "major"},
+        {"H", "major"},
+        {"C", "phrygian"},
+        {"C", ""},
+    }
+    for _, tc := range cases {
+        if got := ToCamelot(tc.key, tc.scale); got != "" {
+            t.Errorf("ToCamelot(%q, %q) = %q, want empty", tc.key, tc.scale, got)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test, verify fails**
+
+```bash
+cd backend && go test ./analysis/...
+```
+
+Expected: FAIL with "undefined: ToCamelot".
+
+- [ ] **Step 3: Implement `ToCamelot`**
+
+Create `backend/analysis/camelot.go`:
+
+```go
+package analysis
+
+// ToCamelot converts a musical key + scale ("A" + "minor") to Camelot wheel
+// notation ("8A"). Returns empty string for unrecognized inputs.
+//
+// The Camelot wheel indexes the 12 major keys as 1B..12B and the 12 minor
+// keys as 1A..12A, ordered so that +1/-1 and same-number-other-letter keys
+// are harmonically compatible.
+func ToCamelot(key, scale string) string {
+    majorToCamelot := map[string]string{
+        "C": "8B", "G": "9B", "D": "10B", "A": "11B", "E": "12B", "B": "1B",
+        "F#": "2B", "Gb": "2B",
+        "Db": "3B", "C#": "3B",
+        "Ab": "4B", "G#": "4B",
+        "Eb": "5B", "D#": "5B",
+        "Bb": "6B", "A#": "6B",
+        "F": "7B",
+    }
+    minorToCamelot := map[string]string{
+        "A": "8A", "E": "9A", "B": "10A",
+        "F#": "11A", "Gb": "11A",
+        "C#": "12A", "Db": "12A",
+        "G#": "1A", "Ab": "1A",
+        "Eb": "2A", "D#": "2A",
+        "Bb": "3A", "A#": "3A",
+        "F": "4A", "C": "5A", "G": "6A", "D": "7A",
+    }
+    switch scale {
+    case "major":
+        return majorToCamelot[key]
+    case "minor":
+        return minorToCamelot[key]
+    default:
+        return ""
+    }
+}
+```
+
+- [ ] **Step 4: Run test, verify passes**
+
+```bash
+cd backend && go test ./analysis/... -v
+```
+
+Expected: PASS for `TestToCamelot` and `TestToCamelot_Invalid`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/analysis/camelot.go backend/analysis/camelot_test.go
+git commit -m "feat(analysis): Camelot wheel mapping for musical keys"
+```
+
+---
+
+## Task 3: Essentia JSON parser (TDD)
+
+**Files:**
+- Create: `backend/analysis/essentia_parse.go`
+- Create: `backend/analysis/essentia_parse_test.go`
+- Create: `backend/analysis/testdata/essentia_success.json`
+
+- [ ] **Step 1: Create a realistic fixture**
+
+Create `backend/analysis/testdata/essentia_success.json` (a trimmed representation of what `streaming_extractor_music` emits):
+
+```json
+{
+  "rhythm": {
+    "bpm": 128.04,
+    "bpm_confidence": 3.82
+  },
+  "tonal": {
+    "key_key": "A",
+    "key_scale": "minor",
+    "key_strength": 0.78
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `backend/analysis/essentia_parse_test.go`:
+
+```go
+package analysis
+
+import (
+    "os"
+    "testing"
+)
+
+func TestParseEssentiaOutput_Success(t *testing.T) {
+    raw, err := os.ReadFile("testdata/essentia_success.json")
+    if err != nil {
+        t.Fatalf("read fixture: %v", err)
+    }
+    got, err := ParseEssentiaOutput(raw)
+    if err != nil {
+        t.Fatalf("ParseEssentiaOutput: %v", err)
+    }
+    if got.BPM != 128.04 {
+        t.Errorf("BPM = %v, want 128.04", got.BPM)
+    }
+    // bpm_confidence of 3.82 should normalize to min(3.82/5.0, 1.0) = 0.764
+    if got.BPMConfidence < 0.76 || got.BPMConfidence > 0.77 {
+        t.Errorf("BPMConfidence = %v, want ~0.764", got.BPMConfidence)
+    }
+    if got.Key != "8A" {
+        t.Errorf("Key = %q, want %q", got.Key, "8A")
+    }
+    if got.KeyConfidence != 0.78 {
+        t.Errorf("KeyConfidence = %v, want 0.78", got.KeyConfidence)
+    }
+}
+
+func TestParseEssentiaOutput_MalformedJSON(t *testing.T) {
+    _, err := ParseEssentiaOutput([]byte("{not json"))
+    if err == nil {
+        t.Fatal("expected error for malformed JSON")
+    }
+}
+
+func TestParseEssentiaOutput_MissingBPM(t *testing.T) {
+    raw := []byte(`{"tonal":{"key_key":"A","key_scale":"minor","key_strength":0.5}}`)
+    _, err := ParseEssentiaOutput(raw)
+    if err == nil {
+        t.Fatal("expected error when BPM is missing")
+    }
+}
+
+func TestParseEssentiaOutput_UnknownKey_StillReturnsBPM(t *testing.T) {
+    // An invalid scale should leave Key empty but BPM still populated.
+    raw := []byte(`{"rhythm":{"bpm":120,"bpm_confidence":2.0},"tonal":{"key_key":"C","key_scale":"phrygian","key_strength":0.5}}`)
+    got, err := ParseEssentiaOutput(raw)
+    if err != nil {
+        t.Fatalf("ParseEssentiaOutput: %v", err)
+    }
+    if got.BPM != 120 {
+        t.Errorf("BPM = %v, want 120", got.BPM)
+    }
+    if got.Key != "" {
+        t.Errorf("Key = %q, want empty (unknown scale)", got.Key)
+    }
+    if got.KeyConfidence != 0 {
+        t.Errorf("KeyConfidence = %v, want 0 when key unknown", got.KeyConfidence)
+    }
+}
+
+func TestParseEssentiaOutput_ConfidenceClamped(t *testing.T) {
+    // bpm_confidence > 5.0 should clamp to 1.0
+    raw := []byte(`{"rhythm":{"bpm":120,"bpm_confidence":8.0},"tonal":{"key_key":"A","key_scale":"minor","key_strength":1.5}}`)
+    got, err := ParseEssentiaOutput(raw)
+    if err != nil {
+        t.Fatalf("ParseEssentiaOutput: %v", err)
+    }
+    if got.BPMConfidence != 1.0 {
+        t.Errorf("BPMConfidence = %v, want 1.0", got.BPMConfidence)
+    }
+    if got.KeyConfidence != 1.0 {
+        t.Errorf("KeyConfidence = %v, want 1.0", got.KeyConfidence)
+    }
+}
+```
+
+- [ ] **Step 3: Run test, verify fails**
+
+```bash
+cd backend && go test ./analysis/... -run TestParseEssentiaOutput -v
+```
+
+Expected: FAIL with "undefined: ParseEssentiaOutput".
+
+- [ ] **Step 4: Implement parser**
+
+Create `backend/analysis/essentia_parse.go`:
+
+```go
+package analysis
+
+import (
+    "encoding/json"
+    "errors"
+    "fmt"
+)
+
+// Result is the structured output of an essentia analysis run.
+type Result struct {
+    BPM           float64
+    BPMConfidence float64 // normalized to [0, 1]
+    Key           string  // Camelot notation, e.g. "8A"; "" if unknown
+    KeyConfidence float64 // normalized to [0, 1]; 0 if key unknown
+}
+
+type rawEssentia struct {
+    Rhythm struct {
+        BPM           float64 `json:"bpm"`
+        BPMConfidence float64 `json:"bpm_confidence"`
+    } `json:"rhythm"`
+    Tonal struct {
+        KeyKey      string  `json:"key_key"`
+        KeyScale    string  `json:"key_scale"`
+        KeyStrength float64 `json:"key_strength"`
+    } `json:"tonal"`
+}
+
+// ParseEssentiaOutput reads the JSON written by streaming_extractor_music and
+// returns a normalized Result. Returns an error for malformed JSON or missing
+// BPM (the only truly required field).
+func ParseEssentiaOutput(raw []byte) (Result, error) {
+    var e rawEssentia
+    if err := json.Unmarshal(raw, &e); err != nil {
+        return Result{}, fmt.Errorf("parse essentia json: %w", err)
+    }
+    if e.Rhythm.BPM <= 0 {
+        return Result{}, errors.New("essentia output missing bpm")
+    }
+    camelot := ToCamelot(e.Tonal.KeyKey, e.Tonal.KeyScale)
+    keyConf := normalizeConfidence(e.Tonal.KeyStrength)
+    if camelot == "" {
+        keyConf = 0
+    }
+    return Result{
+        BPM:           e.Rhythm.BPM,
+        BPMConfidence: normalizeConfidence(e.Rhythm.BPMConfidence / 5.0),
+        Key:           camelot,
+        KeyConfidence: keyConf,
+    }, nil
+}
+
+func normalizeConfidence(x float64) float64 {
+    if x < 0 {
+        return 0
+    }
+    if x > 1 {
+        return 1
+    }
+    return x
+}
+```
+
+- [ ] **Step 5: Run test, verify passes**
+
+```bash
+cd backend && go test ./analysis/... -run TestParseEssentiaOutput -v
+```
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/analysis/essentia_parse.go backend/analysis/essentia_parse_test.go \
+        backend/analysis/testdata/essentia_success.json
+git commit -m "feat(analysis): parse essentia JSON output with confidence normalization"
+```
+
+---
+
+## Task 4: Essentia subprocess wrapper (TDD with stub binary)
+
+**Files:**
+- Create: `backend/analysis/essentia.go`
+- Create: `backend/analysis/essentia_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/analysis/essentia_test.go`:
+
+```go
+package analysis
+
+import (
+    "context"
+    "errors"
+    "os"
+    "path/filepath"
+    "runtime"
+    "testing"
+    "time"
+)
+
+// writeStubBinary creates a fake streaming_extractor_music in a temp dir that
+// writes the supplied JSON to its second argument and exits 0. Returns the
+// directory path so the caller can prepend it to PATH.
+func writeStubBinary(t *testing.T, outputJSON string) string {
+    t.Helper()
+    if runtime.GOOS == "windows" {
+        t.Skip("stub shell script requires a POSIX shell")
+    }
+    dir := t.TempDir()
+    script := "#!/usr/bin/env bash\nprintf '%s' '" + outputJSON + "' > \"$2\"\n"
+    path := filepath.Join(dir, "streaming_extractor_music")
+    if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+        t.Fatalf("write stub: %v", err)
+    }
+    return dir
+}
+
+func withPathPrepended(t *testing.T, dir string) {
+    t.Helper()
+    prev := os.Getenv("PATH")
+    os.Setenv("PATH", dir+string(os.PathListSeparator)+prev)
+    t.Cleanup(func() { os.Setenv("PATH", prev) })
+}
+
+func TestAnalyzer_Analyze_Success(t *testing.T) {
+    stubDir := writeStubBinary(t, `{"rhythm":{"bpm":124.0,"bpm_confidence":4.0},"tonal":{"key_key":"C","key_scale":"major","key_strength":0.9}}`)
+    withPathPrepended(t, stubDir)
+
+    audio := filepath.Join(t.TempDir(), "fake.wav")
+    os.WriteFile(audio, []byte("fake"), 0644)
+
+    a := NewAnalyzer(30 * time.Second)
+    got, err := a.Analyze(context.Background(), audio)
+    if err != nil {
+        t.Fatalf("Analyze: %v", err)
+    }
+    if got.BPM != 124.0 {
+        t.Errorf("BPM = %v, want 124.0", got.BPM)
+    }
+    if got.Key != "8B" {
+        t.Errorf("Key = %q, want 8B", got.Key)
+    }
+}
+
+func TestAnalyzer_Analyze_BinaryMissing(t *testing.T) {
+    os.Setenv("PATH", "/nonexistent")
+    t.Cleanup(func() { os.Setenv("PATH", "/usr/bin:/bin") })
+
+    a := NewAnalyzer(30 * time.Second)
+    _, err := a.Analyze(context.Background(), "/tmp/anything.wav")
+    if !errors.Is(err, ErrBinaryMissing) {
+        t.Fatalf("want ErrBinaryMissing, got %v", err)
+    }
+}
+
+func TestAnalyzer_Analyze_FileMissing(t *testing.T) {
+    // Stub exits 0 but we want the wrapper to return ErrFileMissing before
+    // even calling the binary.
+    stubDir := writeStubBinary(t, `{"rhythm":{"bpm":120,"bpm_confidence":2.0},"tonal":{"key_key":"A","key_scale":"minor","key_strength":0.5}}`)
+    withPathPrepended(t, stubDir)
+
+    a := NewAnalyzer(30 * time.Second)
+    _, err := a.Analyze(context.Background(), "/tmp/definitely-does-not-exist-xyz.wav")
+    if !errors.Is(err, ErrFileMissing) {
+        t.Fatalf("want ErrFileMissing, got %v", err)
+    }
+}
+
+func TestAnalyzer_Analyze_MalformedOutput(t *testing.T) {
+    stubDir := writeStubBinary(t, `{not json`)
+    withPathPrepended(t, stubDir)
+
+    audio := filepath.Join(t.TempDir(), "fake.wav")
+    os.WriteFile(audio, []byte("fake"), 0644)
+
+    a := NewAnalyzer(30 * time.Second)
+    _, err := a.Analyze(context.Background(), audio)
+    if !errors.Is(err, ErrMalformedOutput) {
+        t.Fatalf("want ErrMalformedOutput, got %v", err)
+    }
+}
+```
+
+- [ ] **Step 2: Run test, verify fails**
+
+```bash
+cd backend && go test ./analysis/... -run TestAnalyzer -v
+```
+
+Expected: FAIL with "undefined: NewAnalyzer / ErrBinaryMissing / ErrFileMissing / ErrMalformedOutput".
+
+- [ ] **Step 3: Implement the wrapper**
+
+Create `backend/analysis/essentia.go`:
+
+```go
+package analysis
+
+import (
+    "context"
+    "errors"
+    "fmt"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "time"
+)
+
+// Sentinel errors so callers (the manager) can decide retry policy.
+var (
+    ErrBinaryMissing   = errors.New("essentia binary not found on PATH")
+    ErrFileMissing     = errors.New("audio file not found")
+    ErrTimeout         = errors.New("essentia analysis timed out")
+    ErrMalformedOutput = errors.New("essentia produced malformed output")
+)
+
+const binaryName = "streaming_extractor_music"
+
+// Analyzer wraps the streaming_extractor_music binary.
+type Analyzer struct {
+    timeout time.Duration
+}
+
+func NewAnalyzer(timeout time.Duration) *Analyzer {
+    return &Analyzer{timeout: timeout}
+}
+
+// BinaryAvailable reports whether the essentia binary is on PATH. Call once
+// at startup to decide whether to start the ticker.
+func BinaryAvailable() bool {
+    _, err := exec.LookPath(binaryName)
+    return err == nil
+}
+
+// Analyze runs the essentia extractor on the given audio file path.
+func (a *Analyzer) Analyze(ctx context.Context, audioPath string) (Result, error) {
+    if _, err := exec.LookPath(binaryName); err != nil {
+        return Result{}, ErrBinaryMissing
+    }
+    if _, err := os.Stat(audioPath); err != nil {
+        if os.IsNotExist(err) {
+            return Result{}, ErrFileMissing
+        }
+        return Result{}, fmt.Errorf("stat audio: %w", err)
+    }
+
+    outDir, err := os.MkdirTemp("", "essentia-*")
+    if err != nil {
+        return Result{}, fmt.Errorf("mktemp: %w", err)
+    }
+    defer os.RemoveAll(outDir)
+    outPath := filepath.Join(outDir, "out.json")
+
+    runCtx, cancel := context.WithTimeout(ctx, a.timeout)
+    defer cancel()
+
+    cmd := exec.CommandContext(runCtx, binaryName, audioPath, outPath)
+    output, err := cmd.CombinedOutput()
+    if runCtx.Err() == context.DeadlineExceeded {
+        return Result{}, ErrTimeout
+    }
+    if err != nil {
+        return Result{}, fmt.Errorf("essentia exec failed: %w (output: %s)", err, string(output))
+    }
+
+    raw, err := os.ReadFile(outPath)
+    if err != nil {
+        return Result{}, fmt.Errorf("read essentia output: %w", err)
+    }
+    result, err := ParseEssentiaOutput(raw)
+    if err != nil {
+        return Result{}, fmt.Errorf("%w: %v", ErrMalformedOutput, err)
+    }
+    return result, nil
+}
+```
+
+- [ ] **Step 4: Run test, verify passes**
+
+```bash
+cd backend && go test ./analysis/... -run TestAnalyzer -v
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/analysis/essentia.go backend/analysis/essentia_test.go
+git commit -m "feat(analysis): essentia subprocess wrapper with sentinel errors"
+```
+
+---
+
+## Task 5: Analysis repository (claim/update/mark-failed with in-memory SQLite)
+
+**Files:**
+- Create: `backend/analysis/repository.go`
+- Create: `backend/analysis/repository_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/analysis/repository_test.go`:
+
+```go
+package analysis
+
+import (
+    "context"
+    "database/sql"
+    "testing"
+    "time"
+
+    _ "github.com/mattn/go-sqlite3"
+)
+
+// newTestDB sets up an in-memory SQLite with just enough schema for the repo.
+func newTestDB(t *testing.T) *sql.DB {
+    t.Helper()
+    db, err := sql.Open("sqlite3", ":memory:")
+    if err != nil {
+        t.Fatalf("open: %v", err)
+    }
+    _, err = db.Exec(`
+        CREATE TABLE tracks (
+            id TEXT PRIMARY KEY,
+            owner_user_id TEXT NOT NULL DEFAULT 'u1',
+            original_filename TEXT NOT NULL DEFAULT 'f.wav',
+            content_type TEXT NOT NULL DEFAULT 'audio/wav',
+            size_bytes INTEGER NOT NULL DEFAULT 0,
+            file_path TEXT NOT NULL DEFAULT '/x',
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            bpm REAL,
+            bpm_confidence REAL,
+            musical_key TEXT,
+            key_confidence REAL,
+            analyzed_at DATETIME,
+            analysis_status TEXT NOT NULL DEFAULT 'pending',
+            analysis_error TEXT,
+            analysis_retry_count INTEGER NOT NULL DEFAULT 0,
+            next_retry_at DATETIME
+        );
+    `)
+    if err != nil {
+        t.Fatalf("create: %v", err)
+    }
+    t.Cleanup(func() { db.Close() })
+    return db
+}
+
+func seedPending(t *testing.T, db *sql.DB, id, filePath string) {
+    t.Helper()
+    _, err := db.Exec(`INSERT INTO tracks (id, file_path) VALUES (?, ?)`, id, filePath)
+    if err != nil {
+        t.Fatalf("seed: %v", err)
+    }
+}
+
+func TestRepository_ClaimNextPending_ReturnsPending(t *testing.T) {
+    db := newTestDB(t)
+    seedPending(t, db, "t1", "/audio/t1.wav")
+
+    repo := NewRepository(db)
+    got, err := repo.ClaimNextPending(context.Background())
+    if err != nil {
+        t.Fatalf("ClaimNextPending: %v", err)
+    }
+    if got == nil || got.ID != "t1" {
+        t.Fatalf("got %v, want track t1", got)
+    }
+    if got.FilePath != "/audio/t1.wav" {
+        t.Errorf("FilePath = %q", got.FilePath)
+    }
+}
+
+func TestRepository_ClaimNextPending_NoneAvailable(t *testing.T) {
+    db := newTestDB(t)
+    repo := NewRepository(db)
+    got, err := repo.ClaimNextPending(context.Background())
+    if err != nil {
+        t.Fatalf("ClaimNextPending: %v", err)
+    }
+    if got != nil {
+        t.Fatalf("expected nil, got %v", got)
+    }
+}
+
+func TestRepository_ClaimNextPending_SkipsFutureRetry(t *testing.T) {
+    db := newTestDB(t)
+    seedPending(t, db, "t1", "/a.wav")
+    // Push t1's next_retry_at into the future
+    _, _ = db.Exec(`UPDATE tracks SET next_retry_at = datetime('now', '+1 hour') WHERE id = 't1'`)
+
+    repo := NewRepository(db)
+    got, err := repo.ClaimNextPending(context.Background())
+    if err != nil {
+        t.Fatalf("ClaimNextPending: %v", err)
+    }
+    if got != nil {
+        t.Fatalf("should skip track with future next_retry_at, got %v", got)
+    }
+}
+
+func TestRepository_MarkAnalyzed_UpdatesFields(t *testing.T) {
+    db := newTestDB(t)
+    seedPending(t, db, "t1", "/a.wav")
+    repo := NewRepository(db)
+
+    camKey := "8A"
+    err := repo.MarkAnalyzed(context.Background(), "t1", Result{
+        BPM: 128.0, BPMConfidence: 0.8, Key: camKey, KeyConfidence: 0.78,
+    })
+    if err != nil {
+        t.Fatalf("MarkAnalyzed: %v", err)
+    }
+
+    var status string
+    var bpm sql.NullFloat64
+    var key sql.NullString
+    err = db.QueryRow(`SELECT analysis_status, bpm, musical_key FROM tracks WHERE id='t1'`).Scan(&status, &bpm, &key)
+    if err != nil {
+        t.Fatalf("read: %v", err)
+    }
+    if status != "analyzed" {
+        t.Errorf("status = %q", status)
+    }
+    if !bpm.Valid || bpm.Float64 != 128.0 {
+        t.Errorf("bpm = %v", bpm)
+    }
+    if !key.Valid || key.String != "8A" {
+        t.Errorf("key = %v", key)
+    }
+}
+
+func TestRepository_RecordFailure_IncrementsAndBackoff(t *testing.T) {
+    db := newTestDB(t)
+    seedPending(t, db, "t1", "/a.wav")
+    repo := NewRepository(db)
+
+    // First failure -> still pending, next_retry_at ~10min out
+    err := repo.RecordFailure(context.Background(), "t1", "boom", time.Now())
+    if err != nil {
+        t.Fatalf("RecordFailure: %v", err)
+    }
+    var status string
+    var retryCount int
+    var nextRetry sql.NullTime
+    _ = db.QueryRow(`SELECT analysis_status, analysis_retry_count, next_retry_at FROM tracks WHERE id='t1'`).Scan(&status, &retryCount, &nextRetry)
+    if status != "pending" {
+        t.Errorf("status after 1st failure = %q, want pending", status)
+    }
+    if retryCount != 1 {
+        t.Errorf("retry_count = %d, want 1", retryCount)
+    }
+    if !nextRetry.Valid {
+        t.Fatalf("next_retry_at not set")
+    }
+
+    // Third failure -> terminal
+    _ = repo.RecordFailure(context.Background(), "t1", "boom", time.Now())
+    _ = repo.RecordFailure(context.Background(), "t1", "boom", time.Now())
+
+    _ = db.QueryRow(`SELECT analysis_status, analysis_retry_count FROM tracks WHERE id='t1'`).Scan(&status, &retryCount)
+    if status != "failed" {
+        t.Errorf("status after 3rd failure = %q, want failed", status)
+    }
+    if retryCount != 3 {
+        t.Errorf("retry_count = %d, want 3", retryCount)
+    }
+}
+
+func TestRepository_RecordTerminalFailure_SetsFailedImmediately(t *testing.T) {
+    db := newTestDB(t)
+    seedPending(t, db, "t1", "/a.wav")
+    repo := NewRepository(db)
+
+    err := repo.RecordTerminalFailure(context.Background(), "t1", "file missing")
+    if err != nil {
+        t.Fatalf("RecordTerminalFailure: %v", err)
+    }
+    var status string
+    _ = db.QueryRow(`SELECT analysis_status FROM tracks WHERE id='t1'`).Scan(&status)
+    if status != "failed" {
+        t.Errorf("status = %q, want failed", status)
+    }
+}
+```
+
+- [ ] **Step 2: Run test, verify fails**
+
+```bash
+cd backend && go test ./analysis/... -run TestRepository -v
+```
+
+Expected: FAIL with "undefined: NewRepository".
+
+- [ ] **Step 3: Implement the repository**
+
+Create `backend/analysis/repository.go`:
+
+```go
+package analysis
+
+import (
+    "context"
+    "database/sql"
+    "time"
+)
+
+const maxRetries = 3
+
+// backoffFor returns the time until the next retry attempt given how many
+// failures have already been recorded (1-based).
+func backoffFor(retryCount int) time.Duration {
+    switch retryCount {
+    case 1:
+        return 10 * time.Minute
+    case 2:
+        return 1 * time.Hour
+    default:
+        return 6 * time.Hour
+    }
+}
+
+// ClaimedTrack holds the minimum info needed to run analysis.
+type ClaimedTrack struct {
+    ID       string
+    FilePath string
+}
+
+// Repository reads/writes analysis fields on the tracks table. It accepts a
+// *sql.DB directly (not the project's *db.DB wrapper) so tests can use an
+// in-memory SQLite.
+type Repository struct {
+    db *sql.DB
+}
+
+func NewRepository(db *sql.DB) *Repository {
+    return &Repository{db: db}
+}
+
+// ClaimNextPending returns the next track eligible for analysis, or nil if
+// none. Eligibility: analysis_status='pending' AND next_retry_at is null or
+// in the past. Sorted by upload order so backfill drains oldest first.
+func (r *Repository) ClaimNextPending(ctx context.Context) (*ClaimedTrack, error) {
+    row := r.db.QueryRowContext(ctx, `
+        SELECT id, file_path
+        FROM tracks
+        WHERE analysis_status = 'pending'
+          AND (next_retry_at IS NULL OR next_retry_at <= datetime('now'))
+        ORDER BY created_at ASC
+        LIMIT 1
+    `)
+    var t ClaimedTrack
+    err := row.Scan(&t.ID, &t.FilePath)
+    if err == sql.ErrNoRows {
+        return nil, nil
+    }
+    if err != nil {
+        return nil, err
+    }
+    return &t, nil
+}
+
+// MarkAnalyzed writes a successful result and flips status to 'analyzed'.
+// If the key is empty (unknown), musical_key is set NULL but the row is still
+// considered analyzed.
+func (r *Repository) MarkAnalyzed(ctx context.Context, id string, res Result) error {
+    var key interface{}
+    if res.Key != "" {
+        key = res.Key
+    }
+    _, err := r.db.ExecContext(ctx, `
+        UPDATE tracks
+        SET bpm = ?, bpm_confidence = ?, musical_key = ?, key_confidence = ?,
+            analyzed_at = datetime('now'),
+            analysis_status = 'analyzed',
+            analysis_error = NULL,
+            next_retry_at = NULL,
+            updated_at = datetime('now')
+        WHERE id = ?
+    `, res.BPM, res.BPMConfidence, key, res.KeyConfidence, id)
+    return err
+}
+
+// RecordFailure increments retry_count and schedules the next attempt. After
+// maxRetries failures the status flips to 'failed' (terminal).
+func (r *Repository) RecordFailure(ctx context.Context, id, errMsg string, now time.Time) error {
+    tx, err := r.db.BeginTx(ctx, nil)
+    if err != nil {
+        return err
+    }
+    defer tx.Rollback()
+
+    var current int
+    err = tx.QueryRowContext(ctx, `SELECT analysis_retry_count FROM tracks WHERE id=?`, id).Scan(&current)
+    if err != nil {
+        return err
+    }
+    next := current + 1
+    if next >= maxRetries {
+        _, err = tx.ExecContext(ctx, `
+            UPDATE tracks
+            SET analysis_status = 'failed',
+                analysis_retry_count = ?,
+                analysis_error = ?,
+                next_retry_at = NULL,
+                updated_at = datetime('now')
+            WHERE id = ?
+        `, next, errMsg, id)
+    } else {
+        retryAt := now.Add(backoffFor(next))
+        _, err = tx.ExecContext(ctx, `
+            UPDATE tracks
+            SET analysis_status = 'pending',
+                analysis_retry_count = ?,
+                analysis_error = ?,
+                next_retry_at = ?,
+                updated_at = datetime('now')
+            WHERE id = ?
+        `, next, errMsg, retryAt, id)
+    }
+    if err != nil {
+        return err
+    }
+    return tx.Commit()
+}
+
+// RecordTerminalFailure flips a track straight to 'failed' with no retries.
+// Use for non-recoverable errors (e.g. file missing on disk).
+func (r *Repository) RecordTerminalFailure(ctx context.Context, id, errMsg string) error {
+    _, err := r.db.ExecContext(ctx, `
+        UPDATE tracks
+        SET analysis_status = 'failed',
+            analysis_error = ?,
+            next_retry_at = NULL,
+            updated_at = datetime('now')
+        WHERE id = ?
+    `, errMsg, id)
+    return err
+}
+```
+
+- [ ] **Step 4: Run test, verify passes**
+
+```bash
+cd backend && go test ./analysis/... -run TestRepository -v
+```
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/analysis/repository.go backend/analysis/repository_test.go
+git commit -m "feat(analysis): repository for claim/update/fail track analysis"
+```
+
+---
+
+## Task 6: Analysis manager (orchestration, TDD)
+
+**Files:**
+- Create: `backend/analysis/manager.go`
+- Create: `backend/analysis/manager_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/analysis/manager_test.go`:
+
+```go
+package analysis
+
+import (
+    "context"
+    "database/sql"
+    "errors"
+    "testing"
+)
+
+// fakeAnalyzer returns canned results or errors for tests.
+type fakeAnalyzer struct {
+    result Result
+    err    error
+    calls  int
+}
+
+func (f *fakeAnalyzer) Analyze(ctx context.Context, path string) (Result, error) {
+    f.calls++
+    return f.result, f.err
+}
+
+func TestManager_ProcessOne_NoPending(t *testing.T) {
+    db := newTestDB(t)
+    repo := NewRepository(db)
+    fa := &fakeAnalyzer{}
+    m := NewManager(repo, fa)
+
+    processed, err := m.ProcessOne(context.Background())
+    if err != nil {
+        t.Fatalf("ProcessOne: %v", err)
+    }
+    if processed {
+        t.Error("expected processed=false when nothing to do")
+    }
+    if fa.calls != 0 {
+        t.Errorf("analyzer called %d times, want 0", fa.calls)
+    }
+}
+
+func TestManager_ProcessOne_Success(t *testing.T) {
+    db := newTestDB(t)
+    seedPending(t, db, "t1", "/a.wav")
+    repo := NewRepository(db)
+    fa := &fakeAnalyzer{result: Result{BPM: 128, BPMConfidence: 0.8, Key: "8A", KeyConfidence: 0.7}}
+    m := NewManager(repo, fa)
+
+    processed, err := m.ProcessOne(context.Background())
+    if err != nil {
+        t.Fatalf("ProcessOne: %v", err)
+    }
+    if !processed {
+        t.Error("expected processed=true")
+    }
+
+    var status string
+    var bpm sql.NullFloat64
+    _ = db.QueryRow(`SELECT analysis_status, bpm FROM tracks WHERE id='t1'`).Scan(&status, &bpm)
+    if status != "analyzed" || bpm.Float64 != 128 {
+        t.Errorf("status=%q bpm=%v", status, bpm)
+    }
+}
+
+func TestManager_ProcessOne_RetryableFailure(t *testing.T) {
+    db := newTestDB(t)
+    seedPending(t, db, "t1", "/a.wav")
+    repo := NewRepository(db)
+    fa := &fakeAnalyzer{err: ErrTimeout}
+    m := NewManager(repo, fa)
+
+    _, err := m.ProcessOne(context.Background())
+    if err != nil {
+        t.Fatalf("ProcessOne: %v", err)
+    }
+
+    var status string
+    var retryCount int
+    _ = db.QueryRow(`SELECT analysis_status, analysis_retry_count FROM tracks WHERE id='t1'`).Scan(&status, &retryCount)
+    if status != "pending" {
+        t.Errorf("status=%q, want pending after 1st retryable failure", status)
+    }
+    if retryCount != 1 {
+        t.Errorf("retry_count=%d, want 1", retryCount)
+    }
+}
+
+func TestManager_ProcessOne_TerminalFailureOnMissingFile(t *testing.T) {
+    db := newTestDB(t)
+    seedPending(t, db, "t1", "/a.wav")
+    repo := NewRepository(db)
+    fa := &fakeAnalyzer{err: ErrFileMissing}
+    m := NewManager(repo, fa)
+
+    _, err := m.ProcessOne(context.Background())
+    if err != nil {
+        t.Fatalf("ProcessOne: %v", err)
+    }
+
+    var status string
+    var retryCount int
+    _ = db.QueryRow(`SELECT analysis_status, analysis_retry_count FROM tracks WHERE id='t1'`).Scan(&status, &retryCount)
+    if status != "failed" {
+        t.Errorf("status=%q, want failed (terminal)", status)
+    }
+    if retryCount != 0 {
+        t.Errorf("retry_count=%d, want 0 for terminal failure", retryCount)
+    }
+}
+
+func TestManager_ProcessOne_BinaryMissingReturnsError(t *testing.T) {
+    db := newTestDB(t)
+    seedPending(t, db, "t1", "/a.wav")
+    repo := NewRepository(db)
+    fa := &fakeAnalyzer{err: ErrBinaryMissing}
+    m := NewManager(repo, fa)
+
+    // ErrBinaryMissing means config is broken; surface it rather than burning
+    // retry budget on every track in the library.
+    _, err := m.ProcessOne(context.Background())
+    if !errors.Is(err, ErrBinaryMissing) {
+        t.Fatalf("want ErrBinaryMissing, got %v", err)
+    }
+
+    var status string
+    var retryCount int
+    _ = db.QueryRow(`SELECT analysis_status, analysis_retry_count FROM tracks WHERE id='t1'`).Scan(&status, &retryCount)
+    if status != "pending" || retryCount != 0 {
+        t.Errorf("status=%q retry=%d, want untouched", status, retryCount)
+    }
+}
+```
+
+- [ ] **Step 2: Run test, verify fails**
+
+```bash
+cd backend && go test ./analysis/... -run TestManager -v
+```
+
+Expected: FAIL with "undefined: NewManager".
+
+- [ ] **Step 3: Implement the manager**
+
+Create `backend/analysis/manager.go`:
+
+```go
+package analysis
+
+import (
+    "context"
+    "errors"
+    "fmt"
+    "time"
+)
+
+// analyzer is the narrow interface the manager needs — lets tests swap in a fake.
+type analyzer interface {
+    Analyze(ctx context.Context, audioPath string) (Result, error)
+}
+
+type Manager struct {
+    repo     *Repository
+    analyzer analyzer
+    now      func() time.Time
+}
+
+func NewManager(repo *Repository, a analyzer) *Manager {
+    return &Manager{repo: repo, analyzer: a, now: time.Now}
+}
+
+// ProcessOne claims the next pending track (if any) and analyzes it.
+// Returns (processed, err). `processed` is true iff a track was claimed;
+// err is only returned for surface-breaking conditions like ErrBinaryMissing.
+// Per-track analysis failures are recorded in the DB and do NOT bubble up.
+func (m *Manager) ProcessOne(ctx context.Context) (bool, error) {
+    claim, err := m.repo.ClaimNextPending(ctx)
+    if err != nil {
+        return false, fmt.Errorf("claim next pending: %w", err)
+    }
+    if claim == nil {
+        return false, nil
+    }
+
+    result, analyzeErr := m.analyzer.Analyze(ctx, claim.FilePath)
+    if analyzeErr != nil {
+        // Surface ErrBinaryMissing so the ticker can back off instead of
+        // marching through every track as failed.
+        if errors.Is(analyzeErr, ErrBinaryMissing) {
+            return false, analyzeErr
+        }
+        if errors.Is(analyzeErr, ErrFileMissing) {
+            if err := m.repo.RecordTerminalFailure(ctx, claim.ID, analyzeErr.Error()); err != nil {
+                fmt.Printf("[analysis] record terminal failure for %s: %v\n", claim.ID, err)
+            }
+            return true, nil
+        }
+        // Timeout, malformed output, exec failure — all retryable.
+        if err := m.repo.RecordFailure(ctx, claim.ID, analyzeErr.Error(), m.now()); err != nil {
+            fmt.Printf("[analysis] record failure for %s: %v\n", claim.ID, err)
+        }
+        return true, nil
+    }
+
+    if err := m.repo.MarkAnalyzed(ctx, claim.ID, result); err != nil {
+        fmt.Printf("[analysis] mark analyzed for %s: %v\n", claim.ID, err)
+        return true, nil
+    }
+    return true, nil
+}
+```
+
+- [ ] **Step 4: Run test, verify passes**
+
+```bash
+cd backend && go test ./analysis/... -run TestManager -v
+```
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/analysis/manager.go backend/analysis/manager_test.go
+git commit -m "feat(analysis): manager orchestrates claim, analyze, and status update"
+```
+
+---
+
+## Task 7: Ticker loop + server wiring
+
+**Files:**
+- Create: `backend/analysis/ticker.go`
+- Modify: `backend/main.go`
+
+- [ ] **Step 1: Write the ticker**
+
+Create `backend/analysis/ticker.go`:
+
+```go
+package analysis
+
+import (
+    "context"
+    "errors"
+    "fmt"
+    "time"
+)
+
+// StartLoop polls for pending tracks on the given interval. Stops when ctx
+// is cancelled. If Analyze returns ErrBinaryMissing, the loop backs off to
+// a longer wait (since no amount of retrying will help until the binary is
+// installed and the server restarted).
+func StartLoop(ctx context.Context, m *Manager, interval time.Duration) {
+    fmt.Printf("[Analysis] Starting loop (interval=%s)\n", interval)
+    ticker := time.NewTicker(interval)
+    defer ticker.Stop()
+
+    backoff := time.Duration(0)
+    for {
+        select {
+        case <-ctx.Done():
+            fmt.Println("[Analysis] Loop stopped")
+            return
+        case <-ticker.C:
+            if backoff > 0 {
+                // Consume this tick to honor backoff.
+                backoff -= interval
+                if backoff < 0 {
+                    backoff = 0
+                }
+                continue
+            }
+            processed, err := m.ProcessOne(ctx)
+            if err != nil {
+                if errors.Is(err, ErrBinaryMissing) {
+                    fmt.Println("[Analysis] essentia binary not available; backing off for 5 minutes")
+                    backoff = 5 * time.Minute
+                    continue
+                }
+                fmt.Printf("[Analysis] ProcessOne error: %v\n", err)
+            }
+            // If processed, immediately loop again to drain the queue faster.
+            // Otherwise wait for the next tick.
+            if processed {
+                // Drain-mode: process next on the following tick, not this one,
+                // to keep the Pi responsive.
+                _ = processed
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Wire into main.go**
+
+In `backend/main.go`, add these imports:
+
+```go
+"github.com/faraz525/home-music-server/backend/analysis"
+```
+
+Below the soundcloud manager initialization (around line 68), add:
+
+```go
+// Initialize analysis (BPM + key detection)
+analysisRepo := analysis.NewRepository(db.DB)
+analyzer := analysis.NewAnalyzer(90 * time.Second)
+analysisManager := analysis.NewManager(analysisRepo, analyzer)
+if analysis.BinaryAvailable() {
+    fmt.Printf("[CrateDrop] Analysis worker enabled (essentia binary found)\n")
+} else {
+    fmt.Printf("[CrateDrop] WARNING: streaming_extractor_music not on PATH — analysis disabled\n")
+}
+```
+
+And below the existing `go soundcloud.StartSyncLoop(...)` line (around line 83), add:
+
+```go
+if analysis.BinaryAvailable() {
+    go analysis.StartLoop(ctx, analysisManager, 10*time.Second)
+}
+```
+
+Note: `db.DB` here refers to the embedded `*sql.DB` field on the project's `*db.DB` wrapper (see `backend/internal/db/db.go:16` — `type DB struct{ *sql.DB }`). So the expression `db.DB` unwraps the wrapper.
+
+- [ ] **Step 3: Build**
+
+```bash
+cd backend && go build ./...
+```
+
+Expected: clean build.
+
+- [ ] **Step 4: Smoke test startup with no binary**
+
+```bash
+PATH=/usr/bin:/bin DATA_DIR=/tmp/cratedrop-test-data2 PORT=8082 go run . &
+SERVER_PID=$!
+sleep 2
+kill $SERVER_PID
+```
+
+Expected: server log shows the "WARNING: streaming_extractor_music not on PATH" line and exits cleanly on SIGTERM.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/analysis/ticker.go backend/main.go
+git commit -m "feat(analysis): background ticker loop and server wiring"
+```
+
+---
+
+## Task 8: PATCH /api/tracks/:id for user overrides (TDD)
+
+**Files:**
+- Create: `backend/tracks/patch_handler.go`
+- Create: `backend/tracks/patch_handler_test.go`
+- Modify: `backend/tracks/tracksmanager.go` — add `UpdateAnalysis` method
+- Modify: `backend/tracks/tracksdata.go` — add `UpdateAnalysis` repo method
+- Modify: `backend/tracks/routes.go` — register PATCH route
+
+- [ ] **Step 1: Add the repo method**
+
+In `backend/tracks/tracksdata.go`, append:
+
+```go
+// UpdateAnalysisOverride sets user-edited BPM and/or key and flips status to 'user_edited'.
+// nil values leave the corresponding column untouched.
+func (r *Repository) UpdateAnalysisOverride(ctx context.Context, trackID string, bpm *float64, musicalKey *string) error {
+    // Build a dynamic SET clause so we only update provided fields.
+    sets := []string{"analysis_status = 'user_edited'", "analysis_error = NULL", "next_retry_at = NULL", "updated_at = CURRENT_TIMESTAMP"}
+    args := []any{}
+    if bpm != nil {
+        sets = append(sets, "bpm = ?")
+        args = append(args, *bpm)
+    }
+    if musicalKey != nil {
+        sets = append(sets, "musical_key = ?")
+        args = append(args, *musicalKey)
+    }
+    args = append(args, trackID)
+    query := "UPDATE tracks SET " + strings.Join(sets, ", ") + " WHERE id = ?"
+    _, err := r.db.ExecContext(ctx, query, args...)
+    return err
+}
+```
+
+Ensure `import "strings"` is present.
+
+- [ ] **Step 2: Add the manager method**
+
+In `backend/tracks/tracksmanager.go`, append:
+
+```go
+// UpdateAnalysisOverride applies a user override to BPM and/or musical key.
+// Caller has already validated ranges and authorized the request.
+func (m *Manager) UpdateAnalysisOverride(ctx context.Context, trackID string, bpm *float64, musicalKey *string) error {
+    return m.repo.UpdateAnalysisOverride(ctx, trackID, bpm, musicalKey)
+}
+```
+
+- [ ] **Step 3: Write the failing handler test**
+
+Create `backend/tracks/patch_handler_test.go`:
+
+```go
+package tracks
+
+import (
+    "net/http/httptest"
+    "strings"
+    "testing"
+
+    "github.com/gin-gonic/gin"
+)
+
+func TestValidateKey(t *testing.T) {
+    valid := []string{"1A", "12B", "7A", "9B"}
+    for _, k := range valid {
+        if !isValidCamelot(k) {
+            t.Errorf("isValidCamelot(%q) = false, want true", k)
+        }
+    }
+    invalid := []string{"", "0A", "13A", "1C", "1a", "A1", "100A"}
+    for _, k := range invalid {
+        if isValidCamelot(k) {
+            t.Errorf("isValidCamelot(%q) = true, want false", k)
+        }
+    }
+}
+
+func TestValidateBPM(t *testing.T) {
+    if !isValidBPM(120) {
+        t.Error("isValidBPM(120) = false, want true")
+    }
+    if isValidBPM(49) {
+        t.Error("isValidBPM(49) = true, want false")
+    }
+    if isValidBPM(251) {
+        t.Error("isValidBPM(251) = true, want false")
+    }
+}
+
+// TestPatchHandler_RejectsInvalidBody verifies the handler rejects malformed
+// payloads with a 400 response. Uses a stub manager via an interface-compatible
+// no-op so we don't need a full DB.
+func TestPatchHandler_RejectsInvalidBody(t *testing.T) {
+    gin.SetMode(gin.TestMode)
+    r := gin.New()
+    r.PATCH("/api/tracks/:id", PatchHandler(nil))
+
+    req := httptest.NewRequest("PATCH", "/api/tracks/abc", strings.NewReader(`{"bpm": 9999}`))
+    req.Header.Set("Content-Type", "application/json")
+    w := httptest.NewRecorder()
+    r.ServeHTTP(w, req)
+
+    if w.Code != 400 {
+        t.Errorf("status = %d, want 400", w.Code)
+    }
+}
+
+func TestPatchHandler_RejectsEmptyBody(t *testing.T) {
+    gin.SetMode(gin.TestMode)
+    r := gin.New()
+    r.PATCH("/api/tracks/:id", PatchHandler(nil))
+
+    req := httptest.NewRequest("PATCH", "/api/tracks/abc", strings.NewReader(`{}`))
+    req.Header.Set("Content-Type", "application/json")
+    w := httptest.NewRecorder()
+    r.ServeHTTP(w, req)
+
+    if w.Code != 400 {
+        t.Errorf("status = %d, want 400 (empty body)", w.Code)
+    }
+}
+```
+
+- [ ] **Step 4: Run test, verify fails**
+
+```bash
+cd backend && go test ./tracks/... -run TestPatch -v
+cd backend && go test ./tracks/... -run TestValidate -v
+```
+
+Expected: FAIL with "undefined: PatchHandler / isValidCamelot / isValidBPM".
+
+- [ ] **Step 5: Implement the handler**
+
+Create `backend/tracks/patch_handler.go`:
+
+```go
+package tracks
+
+import (
+    "context"
+    "net/http"
+    "regexp"
+
+    "github.com/gin-gonic/gin"
+)
+
+type patchTrackRequest struct {
+    BPM        *float64 `json:"bpm,omitempty"`
+    MusicalKey *string  `json:"musical_key,omitempty"`
+}
+
+var camelotRE = regexp.MustCompile(`^(1[0-2]|[1-9])[AB]$`)
+
+func isValidBPM(bpm float64) bool {
+    return bpm >= 50 && bpm <= 250
+}
+
+func isValidCamelot(k string) bool {
+    return camelotRE.MatchString(k)
+}
+
+// PatchHandler handles PATCH /api/tracks/:id for user overrides of BPM/key.
+// `mgr` can be nil only in tests that exercise validation paths.
+func PatchHandler(mgr *Manager) gin.HandlerFunc {
+    return func(c *gin.Context) {
+        var req patchTrackRequest
+        if err := c.ShouldBindJSON(&req); err != nil {
+            c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_body", "message": err.Error()}})
+            return
+        }
+        if req.BPM == nil && req.MusicalKey == nil {
+            c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "empty_patch", "message": "at least one of bpm, musical_key is required"}})
+            return
+        }
+        if req.BPM != nil && !isValidBPM(*req.BPM) {
+            c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_bpm", "message": "bpm must be between 50 and 250"}})
+            return
+        }
+        if req.MusicalKey != nil && !isValidCamelot(*req.MusicalKey) {
+            c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_key", "message": "musical_key must be Camelot notation like 8A or 12B"}})
+            return
+        }
+
+        trackID := c.Param("id")
+        // Guard against nil in tests.
+        if mgr == nil {
+            c.Status(http.StatusNoContent)
+            return
+        }
+
+        userID, _ := c.Get("user_id")
+        track, err := mgr.GetTrack(c.Request.Context(), trackID)
+        if err != nil {
+            c.JSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "not_found", "message": "track not found"}})
+            return
+        }
+        if track.OwnerUserID != userID {
+            // Admin middleware is a separate route; owners-only for PATCH.
+            c.JSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "forbidden", "message": "not your track"}})
+            return
+        }
+
+        if err := mgr.UpdateAnalysisOverride(context.Background(), trackID, req.BPM, req.MusicalKey); err != nil {
+            c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "update_failed", "message": err.Error()}})
+            return
+        }
+        updated, err := mgr.GetTrack(c.Request.Context(), trackID)
+        if err != nil {
+            c.Status(http.StatusNoContent)
+            return
+        }
+        c.JSON(http.StatusOK, gin.H{"success": true, "data": updated})
+    }
+}
+```
+
+- [ ] **Step 6: Register the route**
+
+In `backend/tracks/routes.go`, inside `Routes(...)`, right after `g.GET("/:id", GetHandler(m))`, add:
+
+```go
+g.PATCH("/:id", PatchHandler(m))
+```
+
+- [ ] **Step 7: Run tests, verify passes**
+
+```bash
+cd backend && go test ./tracks/... -run "TestPatch|TestValidate" -v
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 8: Build**
+
+```bash
+cd backend && go build ./...
+```
+
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/tracks/patch_handler.go backend/tracks/patch_handler_test.go \
+        backend/tracks/tracksmanager.go backend/tracks/tracksdata.go \
+        backend/tracks/routes.go
+git commit -m "feat(tracks): PATCH /api/tracks/:id for user BPM/key overrides"
+```
+
+---
+
+## Task 9: Frontend Track type and API client
+
+**Files:**
+- Modify: `frontend/src/types/crates.ts`
+- Modify: `frontend/src/lib/api.ts`
+- Modify: `frontend/src/hooks/useQueries.ts`
+
+- [ ] **Step 1: Extend the Track type**
+
+In `frontend/src/types/crates.ts`, locate the `Track` interface (or export type) and add the optional analysis fields. If it does not exist yet, find the `TrackList` type; the `Track` shape it contains must grow these fields:
+
+```ts
+export interface Track {
+  id: string
+  owner_user_id: string
+  original_filename: string
+  content_type: string
+  size_bytes: number
+  duration_seconds?: number
+  title?: string
+  artist?: string
+  album?: string
+  genre?: string
+  year?: number
+  sample_rate?: number
+  bitrate?: number
+  bpm?: number
+  bpm_confidence?: number
+  musical_key?: string
+  key_confidence?: number
+  analyzed_at?: string
+  analysis_status: 'pending' | 'analyzed' | 'failed' | 'user_edited'
+  file_path: string
+  created_at: string
+  updated_at: string
+}
+```
+
+If the file currently imports `Track` from elsewhere, update that definition instead. If no explicit `Track` interface exists (inferred from API responses), add one in this file and export it.
+
+- [ ] **Step 2: Add the patch API method**
+
+In `frontend/src/lib/api.ts`, extend the `tracksApi` object:
+
+```ts
+export const tracksApi = {
+  getUnsorted: (params?: UnsortedParams) =>
+    api.get('/api/tracks', { params: { ...(params || {}), playlist_id: 'unsorted' } }),
+
+  download: (id: string, filename: string) => {
+    const link = document.createElement('a')
+    link.href = `/api/tracks/${id}/download`
+    link.download = filename
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  },
+
+  patch: (id: string, payload: { bpm?: number; musical_key?: string }) =>
+    api.patch(`/api/tracks/${id}`, payload),
+}
+```
+
+- [ ] **Step 3: Add the mutation hook**
+
+In `frontend/src/hooks/useQueries.ts`, append:
+
+```ts
+export function useUpdateTrackAnalysis() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: { bpm?: number; musical_key?: string } }) =>
+      tracksApi.patch(id, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tracks'] })
+    },
+  })
+}
+```
+
+- [ ] **Step 4: Typecheck**
+
+From the `frontend` directory:
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/types/crates.ts frontend/src/lib/api.ts frontend/src/hooks/useQueries.ts
+git commit -m "feat(frontend): Track type + patch API + useUpdateTrackAnalysis mutation"
+```
+
+---
+
+## Task 10: Frontend track list — BPM and Key columns with confidence dot
+
+**Files:**
+- Modify: `frontend/src/pages/LibraryPage.tsx`
+
+This task only adds display; inline editing comes in Task 11.
+
+- [ ] **Step 1: Add a ConfidenceDot component at the top of the file**
+
+After the `MiniVinyl` component (around line 27), add:
+
+```tsx
+function ConfidenceDot({ status, confidence }: { status: string; confidence?: number }) {
+  let color = 'bg-transparent border border-crate-subtle' // pending
+  let title = 'Analyzing…'
+
+  if (status === 'failed') {
+    color = 'bg-transparent border border-crate-danger'
+    title = 'Analysis failed'
+  } else if (status === 'user_edited') {
+    return null // no dot for user-edited values
+  } else if (status === 'analyzed' && typeof confidence === 'number') {
+    if (confidence > 0.7) {
+      color = 'bg-green-500'
+      title = `High confidence (${Math.round(confidence * 100)}%)`
+    } else if (confidence >= 0.4) {
+      color = 'bg-amber-500'
+      title = `Medium confidence (${Math.round(confidence * 100)}%)`
+    } else {
+      color = 'bg-red-500'
+      title = `Low confidence (${Math.round(confidence * 100)}%)`
+    }
+  }
+
+  return <span className={`inline-block w-2 h-2 rounded-full ${color}`} title={title} />
+}
+```
+
+- [ ] **Step 2: Update the header grid to include BPM and Key columns**
+
+Find the header row (around line 316) and change `grid-cols-[28px_1fr_1fr_100px_60px_40px]` to `grid-cols-[28px_1fr_1fr_70px_70px_100px_60px_40px]`. Insert the two header cells after `<div>Album</div>`:
+
+```tsx
+<div className="text-right">BPM</div>
+<div className="text-right">Key</div>
+```
+
+- [ ] **Step 3: Update the row grid to match**
+
+Find the track row grid (around line 369) and apply the same column template on the `sm:grid-cols-*` part: change to `sm:grid-cols-[28px_1fr_1fr_70px_70px_100px_60px_40px]`.
+
+Insert two new display cells right after the Album div (around line 451):
+
+```tsx
+{/* Desktop: BPM */}
+<div className="hidden sm:flex items-center justify-end gap-1.5 text-sm text-crate-subtle tabular-nums">
+  <ConfidenceDot status={t.analysis_status} confidence={t.bpm_confidence} />
+  <span>{t.bpm ? t.bpm.toFixed(1) : '—'}</span>
+</div>
+
+{/* Desktop: Key */}
+<div className="hidden sm:flex items-center justify-end gap-1.5 text-sm text-crate-subtle">
+  <ConfidenceDot status={t.analysis_status} confidence={t.key_confidence} />
+  <span>{t.musical_key || '—'}</span>
+</div>
+```
+
+- [ ] **Step 4: Build and visually verify**
+
+Run the dev server:
+
+```bash
+cd frontend && npm run dev
+```
+
+Open the library page in a browser. With no tracks analyzed yet, both columns should render "—" with a grey-outlined dot (pending status).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/LibraryPage.tsx
+git commit -m "feat(frontend): BPM and Key columns with confidence indicator"
+```
+
+---
+
+## Task 11: Frontend inline edit for BPM and Key
+
+**Files:**
+- Modify: `frontend/src/pages/LibraryPage.tsx`
+
+- [ ] **Step 1: Add an EditableCell component**
+
+At the top of the file (after `ConfidenceDot`), add:
+
+```tsx
+import type { ReactNode } from 'react'
+
+function EditableCell({
+  value,
+  onSave,
+  validate,
+  display,
+  align = 'right',
+}: {
+  value: string
+  onSave: (next: string) => Promise<void> | void
+  validate: (next: string) => boolean
+  display: ReactNode
+  align?: 'left' | 'right'
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const [saving, setSaving] = useState(false)
+
+  if (!editing) {
+    return (
+      <div
+        onDoubleClick={(e) => { e.stopPropagation(); setDraft(value); setEditing(true) }}
+        className="cursor-text select-none"
+        title="Double-click to edit"
+      >
+        {display}
+      </div>
+    )
+  }
+
+  const commit = async () => {
+    if (!validate(draft)) return
+    setSaving(true)
+    try {
+      await onSave(draft)
+    } finally {
+      setSaving(false)
+      setEditing(false)
+    }
+  }
+
+  return (
+    <input
+      autoFocus
+      value={draft}
+      disabled={saving}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') commit()
+        else if (e.key === 'Escape') setEditing(false)
+      }}
+      className={`input h-6 px-1 py-0 text-sm w-16 ${align === 'right' ? 'text-right' : ''}`}
+    />
+  )
+}
+```
+
+- [ ] **Step 2: Wire up the mutation and swap display cells for EditableCell**
+
+At the top of `LibraryPage`, add to the existing hooks:
+
+```tsx
+import { useCrates, useTracks, useDeleteTrack, useAddTracksToCrate, useRemoveTracksFromCrate, useUpdateTrackAnalysis } from '../hooks/useQueries'
+```
+
+Inside the component (near other mutations):
+
+```tsx
+const updateAnalysisMutation = useUpdateTrackAnalysis()
+
+const saveBpm = useCallback(async (trackId: string, raw: string) => {
+  const bpm = parseFloat(raw)
+  if (!isFinite(bpm) || bpm < 50 || bpm > 250) {
+    toast.error('BPM must be between 50 and 250')
+    return
+  }
+  try {
+    await updateAnalysisMutation.mutateAsync({ id: trackId, payload: { bpm } })
+    toast.success('BPM updated')
+  } catch {
+    toast.error('Failed to update BPM')
+  }
+}, [updateAnalysisMutation, toast])
+
+const saveKey = useCallback(async (trackId: string, raw: string) => {
+  const normalized = raw.trim().toUpperCase()
+  if (!/^(1[0-2]|[1-9])[AB]$/.test(normalized)) {
+    toast.error('Key must be Camelot notation (e.g. 8A, 12B)')
+    return
+  }
+  try {
+    await updateAnalysisMutation.mutateAsync({ id: trackId, payload: { musical_key: normalized } })
+    toast.success('Key updated')
+  } catch {
+    toast.error('Failed to update key')
+  }
+}, [updateAnalysisMutation, toast])
+```
+
+Replace the plain BPM and Key cells added in Task 10 with EditableCell wrappers:
+
+```tsx
+{/* Desktop: BPM (editable) */}
+<div className="hidden sm:flex items-center justify-end gap-1.5 text-sm text-crate-subtle tabular-nums">
+  <ConfidenceDot status={t.analysis_status} confidence={t.bpm_confidence} />
+  <EditableCell
+    value={t.bpm ? t.bpm.toFixed(1) : ''}
+    display={<span>{t.bpm ? t.bpm.toFixed(1) : '—'}</span>}
+    validate={(v) => { const n = parseFloat(v); return isFinite(n) && n >= 50 && n <= 250 }}
+    onSave={(v) => saveBpm(t.id, v)}
+  />
+</div>
+
+{/* Desktop: Key (editable) */}
+<div className="hidden sm:flex items-center justify-end gap-1.5 text-sm text-crate-subtle">
+  <ConfidenceDot status={t.analysis_status} confidence={t.key_confidence} />
+  <EditableCell
+    value={t.musical_key || ''}
+    display={<span>{t.musical_key || '—'}</span>}
+    validate={(v) => /^(1[0-2]|[1-9])[AB]$/i.test(v.trim())}
+    onSave={(v) => saveKey(t.id, v)}
+  />
+</div>
+```
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: zero errors.
+
+- [ ] **Step 4: Manual verification**
+
+With the dev server running, double-click a BPM cell, enter `128.0`, press Enter. The value should persist across a page reload and the confidence dot should disappear (user_edited status).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/LibraryPage.tsx
+git commit -m "feat(frontend): inline edit for BPM and Key on track list"
+```
+
+---
+
+## Task 12: End-to-end smoke test with a real audio file
+
+**Files:** no new files, manual verification
+
+- [ ] **Step 1: Confirm essentia is installed on the dev machine**
+
+```bash
+which streaming_extractor_music
+```
+
+If missing on macOS: `brew install essentia --HEAD`. If missing on Debian/Pi: `sudo apt install essentia-examples` (availability varies by distro — for Pi OS Bookworm it should work; otherwise build from source via `https://essentia.upf.edu/`).
+
+- [ ] **Step 2: Start a clean dev server**
+
+```bash
+rm -rf /tmp/cratedrop-e2e
+DATA_DIR=/tmp/cratedrop-e2e PORT=8083 go run ./backend &
+SERVER_PID=$!
+sleep 2
+```
+
+Expected: log includes "Analysis worker enabled (essentia binary found)" and "Starting loop (interval=10s)".
+
+- [ ] **Step 3: Create a user and upload a known track**
+
+Use the frontend at `http://localhost:8083` (or the dev server proxy). Sign up, upload a short WAV file you know the BPM/key of (e.g. a 120 BPM house loop).
+
+- [ ] **Step 4: Wait for analysis**
+
+Watch the server log. Within ~60 seconds you should see no errors and the track's row in SQLite should have `analysis_status='analyzed'`:
+
+```bash
+sqlite3 /tmp/cratedrop-e2e/db/cratedrop.sqlite \
+  "SELECT id, original_filename, bpm, musical_key, analysis_status FROM tracks;"
+```
+
+Expected: row shows a BPM value ±2 of the true tempo and a plausible Camelot key.
+
+- [ ] **Step 5: Verify UI**
+
+Refresh the library page. BPM and Key columns should show the detected values with confidence dots.
+
+- [ ] **Step 6: Verify inline edit**
+
+Double-click the BPM cell, change to a wrong-on-purpose value, save. Refresh. Value persists and confidence dot is gone.
+
+- [ ] **Step 7: Clean up**
+
+```bash
+kill $SERVER_PID
+```
+
+- [ ] **Step 8: Commit (if any doc touchups happened)**
+
+No code changes expected. If the task surfaced bugs, fix them in a follow-up commit before moving on.
+
+---
+
+## Task 13: Deploy-prereq checks and README note
+
+**Files:**
+- Modify: `deploy-local.sh`
+- Modify: `deploy-prod.sh`
+- Modify: `README.md`
+
+- [ ] **Step 1: Add a binary check to each deploy script**
+
+At the top of `deploy-local.sh` and `deploy-prod.sh` (after the shebang), add:
+
+```bash
+if ! command -v streaming_extractor_music >/dev/null 2>&1; then
+  echo "WARNING: streaming_extractor_music not found on PATH."
+  echo "         BPM/key analysis will be disabled until it is installed."
+  echo "         Debian/Pi OS: sudo apt install essentia-examples"
+  echo "         macOS:        brew install essentia --HEAD"
+fi
+```
+
+Do NOT make this a hard failure — the server must still start.
+
+- [ ] **Step 2: Document the prereq in the README**
+
+Add a short section (under existing "Deployment" or similar):
+
+```markdown
+## Optional: BPM & Musical Key Analysis
+
+CrateDrop can auto-detect BPM and musical key (Camelot notation) for uploaded
+tracks. This requires the `streaming_extractor_music` binary from essentia to
+be on PATH.
+
+- Debian / Raspberry Pi OS: `sudo apt install essentia-examples`
+- macOS: `brew install essentia --HEAD`
+
+If the binary is not available, the server logs a warning at startup and
+disables the analysis worker — upload and playback continue to work normally.
+Tracks remain in `pending` status and are analyzed automatically the first
+time the server starts with the binary installed.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy-local.sh deploy-prod.sh README.md
+git commit -m "docs: deploy prereqs and README note for essentia analysis"
+```
+
+---
+
+## Done
+
+At this point:
+
+- Every existing track and every future upload is auto-analyzed for BPM and key.
+- The library page shows BPM and Key columns with confidence dots.
+- Users can double-click to override wrong detections; overrides persist.
+- The analysis worker gracefully disables itself if essentia is missing.
+- All new logic has unit tests; aggregate backend coverage for the `analysis/` package meets the 80% bar.
+
+Final verification:
+
+```bash
+cd backend && go test ./... -cover
+cd frontend && npx tsc --noEmit
+```
+
+Expected: all tests pass; `backend/analysis` coverage ≥ 80%.

--- a/docs/superpowers/specs/2026-04-16-bpm-key-analysis-design.md
+++ b/docs/superpowers/specs/2026-04-16-bpm-key-analysis-design.md
@@ -1,0 +1,217 @@
+# BPM & Musical Key Analysis — Design
+
+**Date:** 2026-04-16
+**Status:** Draft
+**Feature #:** 1 of the DJ-productivity roadmap
+
+## Problem
+
+CrateDrop stores and plays tracks, but has no tempo or key metadata. DJs cannot:
+
+- Build crates filtered by BPM range
+- Identify harmonically compatible tracks
+- Sort a library by tempo for set construction
+
+Every other planned DJ feature (smart crates, "plays well next", Rekordbox export) depends on having BPM and musical key.
+
+## Goal
+
+Every track in the library has a detected BPM and musical key (Camelot notation), viewable in the track list. Detection runs asynchronously without blocking uploads or the HTTP API. Users can override wrong detections.
+
+## Non-Goals (v1)
+
+- Energy, loudness, danceability, or other audio features
+- Bulk edit UI
+- "Re-analyze" button (manual edit is the escape hatch)
+- Filter bar by BPM range or key compatibility (feature #4: smart crates)
+- Harmonic mixing suggestions (feature #5)
+- Rekordbox/Serato export (feature #2)
+- Waveform visualization (feature #3)
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Analysis engine | essentia `streaming_extractor_music` | Single CLI, JSON output, fits existing FFprobe subprocess pattern. No Python runtime needed. |
+| Scope | Backfill entire library + analyze every new upload | Whole library becomes DJ-ready immediately. |
+| Manual edit | Editable with confidence shown | ~5–10% of detections are wrong; users need an escape hatch. Confidence dot helps them know which to review. |
+| UI surface | Track list columns only (v1) | Two new columns (BPM, Key), sortable, inline-editable. Filter bar and detail view deferred. |
+| Worker model | In-process goroutine, DB-polled, concurrency=1 | Matches the existing SoundCloud ticker pattern. Crash-safe via SQLite atomic updates. One analysis at a time keeps the Pi responsive for HTTP traffic. |
+
+## Architecture
+
+A new `backend/analysis/` module, structured to match the existing `backend/soundcloud/` layout:
+
+```
+backend/analysis/
+  essentia.go    # subprocess wrapper: Analyze(ctx, path) (Result, error)
+  camelot.go     # pure mapping: ToCamelot(key, scale) string
+  ticker.go      # background loop, started from server boot
+  manager.go     # DB claim + update logic
+  repository.go  # SQL for reading/writing analysis fields
+```
+
+The ticker runs inside the main Go server process, started from `server/` alongside the SoundCloud ticker. On each 10-second tick:
+
+1. `SELECT id, file_path FROM tracks WHERE analysis_status='pending' AND (next_retry_at IS NULL OR next_retry_at <= datetime('now')) ORDER BY uploaded_at LIMIT 1`
+2. Shell out to `streaming_extractor_music <input> <output_json>`
+3. Parse JSON, map key+scale to Camelot
+4. `UPDATE tracks SET bpm=?, bpm_confidence=?, musical_key=?, key_confidence=?, analyzed_at=datetime('now'), analysis_status='analyzed' WHERE id=?`
+
+On failure, the track remains `analysis_status='pending'` with `analysis_retry_count` incremented and `next_retry_at` set via exponential backoff (10m, 1h, 6h). After 3 failed attempts the status flips to `failed` and the worker stops retrying it. This keeps the ticker query simple (one status for "eligible work") while still surfacing terminal failures in the UI.
+
+## Data Model
+
+Migration: `backend/internal/db/migrations/003_add_track_analysis.sql`
+
+```sql
+ALTER TABLE tracks ADD COLUMN bpm REAL;
+ALTER TABLE tracks ADD COLUMN bpm_confidence REAL;
+ALTER TABLE tracks ADD COLUMN musical_key TEXT;              -- Camelot, e.g. "8A"
+ALTER TABLE tracks ADD COLUMN key_confidence REAL;
+ALTER TABLE tracks ADD COLUMN analyzed_at TIMESTAMP;
+ALTER TABLE tracks ADD COLUMN analysis_status TEXT NOT NULL DEFAULT 'pending';
+ALTER TABLE tracks ADD COLUMN analysis_error TEXT;
+ALTER TABLE tracks ADD COLUMN analysis_retry_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE tracks ADD COLUMN next_retry_at TIMESTAMP;
+CREATE INDEX idx_tracks_analysis_status ON tracks(analysis_status, next_retry_at);
+```
+
+`analysis_status` values:
+- `pending` — not yet analyzed (default for new and backfilled rows)
+- `analyzed` — detection succeeded
+- `failed` — detection failed (retries exhausted or non-retryable, e.g. file missing)
+- `user_edited` — user manually set BPM or key; terminal state, not touched by the worker
+
+Backfill is automatic: because the default is `pending`, existing rows become eligible for analysis as soon as the migration runs.
+
+## Components
+
+### `backend/analysis/essentia.go`
+
+```go
+type Result struct {
+    BPM           float64
+    BPMConfidence float64
+    Key           string // Camelot, e.g. "8A"
+    KeyConfidence float64
+}
+
+func Analyze(ctx context.Context, audioPath string) (Result, error)
+```
+
+- Uses `exec.CommandContext` with a 90-second timeout.
+- Writes essentia output to a temp JSON file, reads and parses, deletes the temp file.
+- Ignores fields other than BPM, key, scale, and the respective confidence scores.
+- Returns a typed error (`ErrBinaryMissing`, `ErrTimeout`, `ErrMalformedOutput`, `ErrFileMissing`) so the worker can decide whether to retry.
+
+### `backend/analysis/camelot.go`
+
+Pure function. All 24 mappings covered by unit tests.
+
+```go
+func ToCamelot(key, scale string) string
+// ("A", "minor") -> "8A"
+// ("C", "major") -> "8B"
+// etc.
+```
+
+### `backend/analysis/ticker.go`
+
+```go
+func Start(ctx context.Context, mgr *Manager, interval time.Duration)
+```
+
+Mirrors `backend/soundcloud/ticker.go`. Started from `server/` with a 10s interval.
+
+### `backend/analysis/manager.go`
+
+Orchestrates: claim next track from repo, call `essentia.Analyze`, write result back. Does not log at info level per track (would be noisy during backfill); uses debug. Failures logged at warn with track id + error.
+
+### HTTP API
+
+New endpoint in `backend/tracks/`:
+
+```
+PATCH /api/tracks/:id
+Body: { "bpm"?: number, "musical_key"?: string }
+```
+
+- Validates: `bpm` in `[50, 250]`, `musical_key` matches `^(1[0-2]|[1-9])[AB]$`.
+- On success: updates the specified fields, sets `analysis_status='user_edited'`, clears `analysis_error`.
+- Auth: reuses the existing track-owner or admin guard.
+
+### Frontend
+
+Track list table gains two columns: **BPM** and **Key**. Both sortable. Inline-editable on double-click (text input with client-side validation matching the server rules). Confidence visualized as a colored dot beside the value:
+
+- green: confidence > 0.7
+- amber: 0.4–0.7
+- red: < 0.4
+- grey outline: `pending`
+- red outline: `failed`
+- no dot: `user_edited`
+
+## Data Flow
+
+```
+Upload      -> tracks row inserted, analysis_status='pending'
+Ticker tick -> claims row, runs essentia (15-30s on Pi 4)
+            -> success: writes bpm/key/confidence, status='analyzed'
+            -> failure: increments retry_count, sets next_retry_at
+Frontend    -> React Query refetch picks up new values on next poll or window focus
+User edit   -> PATCH /api/tracks/:id -> status='user_edited', worker ignores
+```
+
+## Error Handling
+
+| Condition | Behavior |
+|---|---|
+| essentia binary not on PATH at startup | Log loudly at boot, skip ticker start, server still runs, tracks stay `pending` |
+| essentia timeout (>90s) | Stay `pending`, retry with backoff, flip to `failed` after 3 attempts |
+| Malformed JSON output | Stay `pending`, retry with backoff, flip to `failed` after 3 attempts |
+| Audio file missing on disk | `failed` immediately, no retry (non-recoverable) |
+| Unknown key returned by essentia | Store BPM with `analyzed` status; `musical_key` left NULL, `key_confidence=0` |
+| DB write fails | Ticker logs and moves on; next tick retries naturally |
+
+Retry backoff: 10 minutes, 1 hour, 6 hours. After 3 failures the track is terminal-`failed` and must be user-edited or re-uploaded.
+
+## Testing
+
+**Unit tests** (`camelot_test.go`, `essentia_test.go`, `manager_test.go`):
+
+- All 24 `ToCamelot` mappings, plus invalid inputs.
+- `essentia.Analyze` JSON parsing against fixture files at `testdata/essentia_*.json`.
+- Manager retry/backoff state machine using a mock clock and a stub essentia implementation.
+
+**Integration tests** (`ticker_integration_test.go`):
+
+- Stub `streaming_extractor_music` as a bash script on PATH that echoes a fixture.
+- In-memory SQLite, seed a `pending` track, run one tick, assert row updated.
+- Seed a `failed` track with past `next_retry_at`, run tick, assert it retries.
+- Seed a `user_edited` track, run tick, assert it is untouched.
+
+**E2E** (Playwright):
+
+- Upload a known fixture track, wait up to 60s, assert the track list renders expected BPM (±2) and key.
+- Double-click the BPM cell, edit, save, assert the value persists and the confidence dot is gone.
+
+**Target coverage:** 80%+ on the `backend/analysis/` package.
+
+## Deploy
+
+essentia's `streaming_extractor_music` must be on PATH on the Pi.
+
+- On Debian Bookworm (Pi OS base): `apt install essentia-examples` provides the binary.
+- Verify at deploy time: `which streaming_extractor_music` in `deploy-local.sh` / `deploy-prod.sh`.
+- If unavailable via apt for the target Pi OS version, document a manual build from source in `README.md` as a deploy prereq.
+
+The server must run even if the binary is missing; it just won't analyze.
+
+## Open Questions
+
+None blocking. Known small decisions to confirm during implementation:
+
+- Exact ticker interval (10s is a starting guess; can tune based on Pi load)
+- Retry backoff values (10m/1h/6h is a starting guess)
+- Frontend confidence dot thresholds (0.4/0.7 is a starting guess)

--- a/frontend/src/hooks/useQueries.ts
+++ b/frontend/src/hooks/useQueries.ts
@@ -132,3 +132,15 @@ export function useDeleteCrate() {
     },
   })
 }
+
+export function useUpdateTrackAnalysis() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: { bpm?: number; musical_key?: string } }) =>
+      tracksApi.patch(id, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tracks'] })
+    },
+  })
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -121,6 +121,9 @@ export const tracksApi = {
     link.click()
     document.body.removeChild(link)
   },
+
+  patch: (id: string, payload: { bpm?: number; musical_key?: string }) =>
+    api.patch(`/api/tracks/${id}`, payload),
 }
 
 // SoundCloud sync API

--- a/frontend/src/pages/LibraryPage.tsx
+++ b/frontend/src/pages/LibraryPage.tsx
@@ -1,10 +1,11 @@
 import { tracksApi } from '../lib/api'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
 import { usePlayer } from '../state/player'
 import { Link, useSearchParams } from 'react-router-dom'
 import { MoreHorizontal, ListPlus, Play, Pause, Music, Download, Disc, Search, X } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
-import { useCrates, useTracks, useDeleteTrack, useAddTracksToCrate, useRemoveTracksFromCrate } from '../hooks/useQueries'
+import { useCrates, useTracks, useDeleteTrack, useAddTracksToCrate, useRemoveTracksFromCrate, useUpdateTrackAnalysis } from '../hooks/useQueries'
 
 function MiniVinyl({ spinning = false }: { spinning?: boolean }) {
   return (
@@ -51,6 +52,70 @@ function ConfidenceDot({ status, confidence }: { status?: string; confidence?: n
   return <span className={`inline-block w-2 h-2 rounded-full ${color}`} title={title} />
 }
 
+function EditableCell({
+  value,
+  onSave,
+  validate,
+  display,
+  align = 'right',
+}: {
+  value: string
+  onSave: (next: string) => Promise<void> | void
+  validate: (next: string) => boolean
+  display: ReactNode
+  align?: 'left' | 'right'
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const [saving, setSaving] = useState(false)
+
+  if (!editing) {
+    return (
+      <div
+        onDoubleClick={(e) => {
+          e.stopPropagation()
+          setDraft(value)
+          setEditing(true)
+        }}
+        className="cursor-text select-none"
+        title="Double-click to edit"
+      >
+        {display}
+      </div>
+    )
+  }
+
+  const commit = async () => {
+    if (!validate(draft)) {
+      setEditing(false)
+      return
+    }
+    setSaving(true)
+    try {
+      await onSave(draft)
+    } finally {
+      setSaving(false)
+      setEditing(false)
+    }
+  }
+
+  return (
+    <input
+      autoFocus
+      value={draft}
+      disabled={saving}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') commit()
+        else if (e.key === 'Escape') setEditing(false)
+      }}
+      className={`input h-6 px-1 py-0 text-sm w-16 ${align === 'right' ? 'text-right' : ''}`}
+    />
+  )
+}
+
 export function LibraryPage() {
   const { play, isPlaying, toggle, queue, index, setCurrentCrate } = usePlayer()
   const current = queue[index]
@@ -82,6 +147,35 @@ export function LibraryPage() {
   const deleteTrackMutation = useDeleteTrack()
   const addTracksMutation = useAddTracksToCrate()
   const removeTracksMutation = useRemoveTracksFromCrate()
+  const updateAnalysisMutation = useUpdateTrackAnalysis()
+
+  const saveBpm = useCallback(async (trackId: string, raw: string) => {
+    const bpm = parseFloat(raw)
+    if (!isFinite(bpm) || bpm < 50 || bpm > 250) {
+      toast.error('BPM must be between 50 and 250')
+      return
+    }
+    try {
+      await updateAnalysisMutation.mutateAsync({ id: trackId, payload: { bpm } })
+      toast.success('BPM updated')
+    } catch {
+      toast.error('Failed to update BPM')
+    }
+  }, [updateAnalysisMutation, toast])
+
+  const saveKey = useCallback(async (trackId: string, raw: string) => {
+    const normalized = raw.trim().toUpperCase()
+    if (!/^(1[0-2]|[1-9])[AB]$/.test(normalized)) {
+      toast.error('Key must be Camelot notation (e.g. 8A, 12B)')
+      return
+    }
+    try {
+      await updateAnalysisMutation.mutateAsync({ id: trackId, payload: { musical_key: normalized } })
+      toast.success('Key updated')
+    } catch {
+      toast.error('Failed to update key')
+    }
+  }, [updateAnalysisMutation, toast])
 
   useEffect(() => {
     const c = searchParams.get('crate')
@@ -477,16 +571,26 @@ export function LibraryPage() {
               {/* Desktop: Album */}
               <div className="hidden sm:block truncate text-sm text-crate-muted">{t.album || '—'}</div>
 
-              {/* Desktop: BPM */}
+              {/* Desktop: BPM (editable) */}
               <div className="hidden sm:flex items-center justify-end gap-1.5 text-sm text-crate-subtle tabular-nums">
                 <ConfidenceDot status={t.analysis_status} confidence={t.bpm_confidence} />
-                <span>{t.bpm ? t.bpm.toFixed(1) : '—'}</span>
+                <EditableCell
+                  value={t.bpm ? t.bpm.toFixed(1) : ''}
+                  display={<span>{t.bpm ? t.bpm.toFixed(1) : '—'}</span>}
+                  validate={(v) => { const n = parseFloat(v); return isFinite(n) && n >= 50 && n <= 250 }}
+                  onSave={(v) => saveBpm(t.id, v)}
+                />
               </div>
 
-              {/* Desktop: Key */}
+              {/* Desktop: Key (editable) */}
               <div className="hidden sm:flex items-center justify-end gap-1.5 text-sm text-crate-subtle">
                 <ConfidenceDot status={t.analysis_status} confidence={t.key_confidence} />
-                <span>{t.musical_key || '—'}</span>
+                <EditableCell
+                  value={t.musical_key || ''}
+                  display={<span>{t.musical_key || '—'}</span>}
+                  validate={(v) => /^(1[0-2]|[1-9])[AB]$/i.test(v.trim())}
+                  onSave={(v) => saveKey(t.id, v)}
+                />
               </div>
 
               {/* Desktop: Date added */}

--- a/frontend/src/pages/LibraryPage.tsx
+++ b/frontend/src/pages/LibraryPage.tsx
@@ -26,6 +26,31 @@ function MiniVinyl({ spinning = false }: { spinning?: boolean }) {
   )
 }
 
+function ConfidenceDot({ status, confidence }: { status?: string; confidence?: number }) {
+  let color = 'bg-transparent border border-crate-subtle' // pending default
+  let title = 'Analyzing…'
+
+  if (status === 'failed') {
+    color = 'bg-transparent border border-crate-danger'
+    title = 'Analysis failed'
+  } else if (status === 'user_edited') {
+    return null // no dot for user-edited values
+  } else if (status === 'analyzed' && typeof confidence === 'number') {
+    if (confidence > 0.7) {
+      color = 'bg-green-500'
+      title = `High confidence (${Math.round(confidence * 100)}%)`
+    } else if (confidence >= 0.4) {
+      color = 'bg-amber-500'
+      title = `Medium confidence (${Math.round(confidence * 100)}%)`
+    } else {
+      color = 'bg-red-500'
+      title = `Low confidence (${Math.round(confidence * 100)}%)`
+    }
+  }
+
+  return <span className={`inline-block w-2 h-2 rounded-full ${color}`} title={title} />
+}
+
 export function LibraryPage() {
   const { play, isPlaying, toggle, queue, index, setCurrentCrate } = usePlayer()
   const current = queue[index]
@@ -313,7 +338,7 @@ export function LibraryPage() {
       {/* Track list */}
       <div className="card overflow-visible">
         {/* Header row - hidden on mobile */}
-        <div className="hidden sm:grid px-4 py-3 text-xs uppercase tracking-wider text-crate-subtle grid-cols-[28px_1fr_1fr_100px_60px_40px] items-center gap-3 border-b border-crate-border bg-crate-elevated/50">
+        <div className="hidden sm:grid px-4 py-3 text-xs uppercase tracking-wider text-crate-subtle grid-cols-[28px_1fr_1fr_70px_70px_100px_60px_40px] items-center gap-3 border-b border-crate-border bg-crate-elevated/50">
           <input
             type="checkbox"
             checked={tracks?.tracks && tracks.tracks.length > 0 && selectedTrackIds.size === tracks.tracks.length}
@@ -325,6 +350,8 @@ export function LibraryPage() {
           />
           <div>Title</div>
           <div>Album</div>
+          <div className="text-right">BPM</div>
+          <div className="text-right">Key</div>
           <div className="text-right">Added</div>
           <div className="text-right">Time</div>
           <div></div>
@@ -366,7 +393,7 @@ export function LibraryPage() {
           return (
             <div
               key={t.id}
-              className={`stagger-item group px-4 py-3 grid grid-cols-[1fr_auto] sm:grid-cols-[28px_1fr_1fr_100px_60px_40px] items-center gap-3 border-b border-crate-border/50 hover:bg-crate-elevated/50 transition-all cursor-move ${isSelected ? 'bg-crate-amber/5 border-l-2 border-l-crate-amber' : ''} ${isDragging ? 'opacity-50' : ''} ${isCurrent ? 'bg-crate-elevated/30' : ''}`}
+              className={`stagger-item group px-4 py-3 grid grid-cols-[1fr_auto] sm:grid-cols-[28px_1fr_1fr_70px_70px_100px_60px_40px] items-center gap-3 border-b border-crate-border/50 hover:bg-crate-elevated/50 transition-all cursor-move ${isSelected ? 'bg-crate-amber/5 border-l-2 border-l-crate-amber' : ''} ${isDragging ? 'opacity-50' : ''} ${isCurrent ? 'bg-crate-elevated/30' : ''}`}
               draggable
               onDragStart={(e) => handleDragStart(e, t.id)}
               onDragEnd={handleDragEnd}
@@ -449,6 +476,18 @@ export function LibraryPage() {
 
               {/* Desktop: Album */}
               <div className="hidden sm:block truncate text-sm text-crate-muted">{t.album || '—'}</div>
+
+              {/* Desktop: BPM */}
+              <div className="hidden sm:flex items-center justify-end gap-1.5 text-sm text-crate-subtle tabular-nums">
+                <ConfidenceDot status={t.analysis_status} confidence={t.bpm_confidence} />
+                <span>{t.bpm ? t.bpm.toFixed(1) : '—'}</span>
+              </div>
+
+              {/* Desktop: Key */}
+              <div className="hidden sm:flex items-center justify-end gap-1.5 text-sm text-crate-subtle">
+                <ConfidenceDot status={t.analysis_status} confidence={t.key_confidence} />
+                <span>{t.musical_key || '—'}</span>
+              </div>
 
               {/* Desktop: Date added */}
               <div className="hidden sm:block text-right text-sm text-crate-subtle">

--- a/frontend/src/types/crates.ts
+++ b/frontend/src/types/crates.ts
@@ -66,6 +66,12 @@ export type Track = {
   year?: number
   sample_rate?: number
   bitrate?: number
+  bpm?: number
+  bpm_confidence?: number
+  musical_key?: string
+  key_confidence?: number
+  analyzed_at?: string
+  analysis_status?: 'pending' | 'analyzed' | 'failed' | 'user_edited'
   file_path?: string
   created_at?: string
   updated_at?: string


### PR DESCRIPTION
## Summary

- Auto-detects BPM and musical key (Camelot notation) for uploaded tracks by shelling out to essentia's `streaming_extractor_music` in a background worker; users see the results as sortable columns in the library with a confidence dot, and can double-click to override wrong detections.
- New Go package `backend/analysis/` (essentia wrapper, JSON parser, Camelot mapper, repository, manager, drain-mode ticker) + migration 003 adding 9 columns to `tracks` + `PATCH /api/tracks/:id` for user overrides.
- Graceful degradation: if the essentia binary is absent the server logs a WARNING and the worker stays off — uploads, playback, and the rest of the API continue to work.

## Design & plan

- Spec: [`docs/superpowers/specs/2026-04-16-bpm-key-analysis-design.md`](docs/superpowers/specs/2026-04-16-bpm-key-analysis-design.md)
- Plan: [`docs/superpowers/plans/2026-04-16-bpm-key-analysis.md`](docs/superpowers/plans/2026-04-16-bpm-key-analysis.md)
- Brainstormed a 5-feature DJ-productivity roadmap; this PR is **feature #1** (foundational — everything else depends on BPM/key data).

## What's in the diff

- **`backend/analysis/`** — new package (~1,400 lines incl. tests). 33 unit/integration tests covering Camelot mapping, essentia output parsing with confidence normalization + NaN handling, subprocess wrapper with sentinel errors, repository claim/retry/failure semantics, manager orchestration, and the drain-mode background ticker.
- **Migration 003** (`backend/internal/db/migrations/003_add_track_analysis.sql`) — adds `bpm`, `bpm_confidence`, `musical_key`, `key_confidence`, `analyzed_at`, `analysis_status`, `analysis_error`, `analysis_retry_count`, `next_retry_at` plus composite index on `(analysis_status, next_retry_at)`. Guard via `pragma_table_info` sentinel in `db.go::migrate()`. Schema.sql updated so fresh DBs match.
- **`PATCH /api/tracks/:id`** — owner-or-admin, validates BPM in [50, 250] and Camelot regex `^(1[0-2]|[1-9])[AB]$`, normalizes key to uppercase, flips `analysis_status` to `user_edited` so the worker never overwrites manual overrides.
- **Frontend** — extended `Track` type, `useUpdateTrackAnalysis` TanStack Query mutation, `ConfidenceDot` + `EditableCell` components on `LibraryPage.tsx`, new sortable BPM/Key columns, double-click inline edit with toast feedback.
- **Playlists repo** — updated the 4 track-scan sites in `playlists/repository.go` so `analysis_status` is populated when tracks are fetched via a crate endpoint (would otherwise serialize as empty string and break the confidence dot).
- **Deploy** — README documents three install paths for essentia (bind-mount from host, extend the Dockerfile with a source build, bare-metal). The original Dockerfile apt install was dropped because `essentia-examples` doesn't exist in Debian Bookworm and the official `mtgupf/essentia` image is amd64-only (Pi target is arm64).

## Correctness callouts

- **Race condition fix** (caught during final review, [4999ee8](../../commit/4999ee8)): `MarkAnalyzed` originally had no status guard while `RecordFailure` did. A long-running analysis completing after a user PATCH would silently overwrite the user's values. Now both paths ignore rows in terminal states (`user_edited`, `failed`). Regression tests added.
- **NaN / out-of-range guards** in the confidence parser + a documented divide-by-5 rescale for essentia's `bpm_confidence` (histogram-peak score, not a probability).
- **Parent-ctx cancellation** preserved through the essentia subprocess wrapper so the manager can distinguish shutdown from analysis failure.
- **Drain-mode ticker** processes back-to-back when tracks are pending — avoids N × 10s idle wait during initial library backfill. Stops cleanly on `ErrBinaryMissing` instead of grinding.

## Known follow-ups (spawned as separate tasks)

- Consolidate 9 duplicated 18-column track SELECTs into a shared `TrackColumns` constant + exported `ScanTrack` helper.
- Add integration tests for the PATCH handler's 403/404/200 auth paths (validation paths are already tested via nil-manager short-circuit).

## Test plan

- [x] `go test ./analysis/... ./tracks/...` — 33 tests pass
- [x] `npx tsc --noEmit` + `npm run build` in `frontend/` — clean
- [x] Fresh-DB migration smoke test: all 9 columns + index created, defaults correct
- [x] Server boot smoke test: WARNING log appears when essentia absent, ticker stays off, PATCH route registered, unauthenticated PATCH returns 401
- [x] Docker image builds on arm64
- [ ] **Manual E2E (requires essentia binary):** upload a known-BPM track, confirm BPM ±2 and plausible Camelot key appear within 60s; double-click BPM cell, edit, confirm persistence + confidence dot disappears; re-trigger an analysis and confirm user edit is not overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)