### PR TITLE
feat(spotify): download Spotify likes as FLAC via monochrome.tf with yt-dlp fallback

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -5,12 +5,13 @@ import (
 )
 
 type Config struct {
-	Port          string
-	DataDir       string
-	JWTSecret     string
-	RefreshSecret string
-	BaseURL       string
-	Env           string
+	Port             string
+	DataDir          string
+	JWTSecret        string
+	RefreshSecret    string
+	BaseURL          string
+	Env              string
+	MonochromeAPIURL string
 }
 
 func FromEnv() *Config {
@@ -23,6 +24,7 @@ func FromEnv() *Config {
 	cfg.RefreshSecret = getEnv("REFRESH_SECRET", "")
 	cfg.BaseURL = getEnv("BASE_URL", "http://localhost")
 	cfg.Env = getEnv("APP_ENV", "development")
+	cfg.MonochromeAPIURL = getEnv("MONOCHROME_API_URL", "")
 	return cfg
 }
 

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -115,5 +115,18 @@ func (d *DB) migrate() error {
 		}
 	}
 
+	// Check if spotify_sync_config table exists
+	var spTableCount int
+	_ = d.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='spotify_sync_config'").Scan(&spTableCount)
+	if spTableCount == 0 {
+		migrationSQL, err := migrationsFS.ReadFile("migrations/003_add_spotify_sync.sql")
+		if err != nil {
+			return fmt.Errorf("failed to read migration 003_add_spotify_sync: %w", err)
+		}
+		if _, err := d.Exec(string(migrationSQL)); err != nil {
+			return fmt.Errorf("failed to execute migration 003_add_spotify_sync: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/backend/internal/db/migrations/003_add_spotify_sync.sql
+++ b/backend/internal/db/migrations/003_add_spotify_sync.sql
@@ -1,0 +1,56 @@
+-- Spotify Sync Configuration (Singleton table for admin)
+CREATE TABLE IF NOT EXISTS spotify_sync_config (
+    id INTEGER PRIMARY KEY DEFAULT 1,
+    access_token TEXT,
+    refresh_token TEXT,
+    token_expires_at DATETIME,
+    owner_user_id TEXT NOT NULL,
+    liked_songs_playlist_id TEXT,
+    enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    last_sync_at DATETIME,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (liked_songs_playlist_id) REFERENCES playlists(id) ON DELETE SET NULL,
+    CHECK (id = 1)
+);
+
+-- Sync history for tracking sync runs
+CREATE TABLE IF NOT EXISTS spotify_sync_history (
+    id TEXT PRIMARY KEY,
+    sync_started_at DATETIME NOT NULL,
+    sync_completed_at DATETIME,
+    tracks_added INTEGER DEFAULT 0,
+    tracks_skipped INTEGER DEFAULT 0,
+    error_message TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_spotify_sync_history_started
+    ON spotify_sync_history(sync_started_at DESC);
+
+-- Track external IDs to avoid re-downloading
+CREATE TABLE IF NOT EXISTS spotify_synced_tracks (
+    id TEXT PRIMARY KEY,
+    spotify_id TEXT NOT NULL UNIQUE,
+    track_id TEXT NOT NULL,
+    synced_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (track_id) REFERENCES tracks(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_spotify_synced_tracks_sp_id
+    ON spotify_synced_tracks(spotify_id);
+
+-- Spotify playlists that are being synced
+CREATE TABLE IF NOT EXISTS spotify_synced_playlists (
+    id TEXT PRIMARY KEY,
+    spotify_playlist_id TEXT NOT NULL UNIQUE,
+    local_playlist_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    last_sync_at DATETIME,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (local_playlist_id) REFERENCES playlists(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_spotify_synced_playlists_sp_id
+    ON spotify_synced_playlists(spotify_playlist_id);

--- a/backend/main.go
+++ b/backend/main.go
@@ -13,6 +13,7 @@ import (
 	idb "github.com/faraz525/home-music-server/backend/internal/db"
 	mlocal "github.com/faraz525/home-music-server/backend/internal/media/metadata/local"
 	slocal "github.com/faraz525/home-music-server/backend/internal/storage/local"
+	"github.com/faraz525/home-music-server/backend/monochrome"
 	"github.com/faraz525/home-music-server/backend/playlists"
 	"github.com/faraz525/home-music-server/backend/server"
 	"github.com/faraz525/home-music-server/backend/soundcloud"
@@ -69,6 +70,15 @@ func main() {
 	)
 	fmt.Printf("[CrateDrop] SoundCloud sync manager initialized\n")
 
+	// Initialize monochrome.tf client (optional — enables FLAC downloads via TIDAL)
+	var monoClient *monochrome.Client
+	if cfg.MonochromeAPIURL != "" {
+		monoClient = monochrome.NewClient(cfg.MonochromeAPIURL, 120*time.Second)
+		fmt.Printf("[CrateDrop] Monochrome client enabled (base: %s)\n", cfg.MonochromeAPIURL)
+	} else {
+		fmt.Printf("[CrateDrop] Monochrome client disabled (set MONOCHROME_API_URL to enable)\n")
+	}
+
 	// Initialize Spotify sync manager
 	spotifyRepo := spotify.NewRepository(db)
 	spotifyManager := spotify.NewManager(
@@ -78,6 +88,7 @@ func main() {
 		extractor,
 		playlistsManager,
 		cfg.DataDir,
+		monoClient,
 	)
 	fmt.Printf("[CrateDrop] Spotify sync manager initialized\n")
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/faraz525/home-music-server/backend/analysis"
@@ -73,10 +74,12 @@ func main() {
 	// Initialize monochrome.tf client (optional — enables FLAC downloads via TIDAL)
 	var monoClient *monochrome.Client
 	if cfg.MonochromeAPIURL != "" {
-		monoClient = monochrome.NewClient(cfg.MonochromeAPIURL, 120*time.Second)
-		fmt.Printf("[CrateDrop] Monochrome client enabled (base: %s)\n", cfg.MonochromeAPIURL)
+		hosts := strings.Split(cfg.MonochromeAPIURL, ",")
+		monoClient = monochrome.NewClient(hosts, 120*time.Second)
+		fmt.Printf("[CrateDrop] Monochrome client enabled (%d backend(s): %v)\n",
+			len(monoClient.Hosts()), monoClient.Hosts())
 	} else {
-		fmt.Printf("[CrateDrop] Monochrome client disabled (set MONOCHROME_API_URL to enable)\n")
+		fmt.Printf("[CrateDrop] Monochrome client disabled (set MONOCHROME_API_URL to enable; comma-separated list supported)\n")
 	}
 
 	// Initialize Spotify sync manager

--- a/backend/main.go
+++ b/backend/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/faraz525/home-music-server/backend/playlists"
 	"github.com/faraz525/home-music-server/backend/server"
 	"github.com/faraz525/home-music-server/backend/soundcloud"
+	"github.com/faraz525/home-music-server/backend/spotify"
 	"github.com/faraz525/home-music-server/backend/tracks"
 )
 
@@ -67,6 +68,18 @@ func main() {
 	)
 	fmt.Printf("[CrateDrop] SoundCloud sync manager initialized\n")
 
+	// Initialize Spotify sync manager
+	spotifyRepo := spotify.NewRepository(db)
+	spotifyManager := spotify.NewManager(
+		spotifyRepo,
+		tracksRepo,
+		storage,
+		extractor,
+		playlistsManager,
+		cfg.DataDir,
+	)
+	fmt.Printf("[CrateDrop] Spotify sync manager initialized\n")
+
 	// Initialize router and API group
 	r, api := server.NewRouter()
 
@@ -77,10 +90,12 @@ func main() {
 	tracks.Routes(tracksManager, playlistsManager)(protected)
 	playlists.Routes(playlistsManager)(protected)
 	soundcloud.Routes(soundcloudManager)(protected)
+	spotify.Routes(spotifyManager)(protected)
 
-	// Start SoundCloud sync loop in background
+	// Start sync loops in background
 	ctx := context.Background()
 	go soundcloud.StartSyncLoop(ctx, soundcloudManager)
+	go spotify.StartSyncLoop(ctx, spotifyManager)
 
 	addr := "0.0.0.0:" + cfg.Port
 	fmt.Printf("[CrateDrop] Server listening on http://%s\n", addr)

--- a/backend/monochrome/client.go
+++ b/backend/monochrome/client.go
@@ -60,12 +60,21 @@ type StreamInfo struct {
 	Codec    string
 }
 
-// SearchByISRC looks up the TIDAL catalog by ISRC and returns zero or more matches.
-func (c *Client) SearchByISRC(ctx context.Context, isrc string) ([]TrackMatch, error) {
-	if strings.TrimSpace(isrc) == "" {
-		return nil, fmt.Errorf("empty ISRC")
+// Search runs a free-text query against the TIDAL catalog and returns up to
+// `limit` matches. The upstream /search/ endpoint accepts only free-text via
+// `s=` — there is no ISRC query param, so ISRC filtering must be done by the
+// caller after reading TrackMatch.ISRC on each result.
+func (c *Client) Search(ctx context.Context, query string, limit int) ([]TrackMatch, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, fmt.Errorf("empty query")
 	}
-	return c.doSearch(ctx, url.Values{"i": {isrc}, "limit": {"5"}})
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+	return c.doSearch(ctx, url.Values{
+		"s":     {query},
+		"limit": {fmt.Sprintf("%d", limit)},
+	})
 }
 
 func (c *Client) doSearch(ctx context.Context, q url.Values) ([]TrackMatch, error) {

--- a/backend/monochrome/client.go
+++ b/backend/monochrome/client.go
@@ -21,27 +21,51 @@ const (
 	QualityLow      = "LOW"
 )
 
-// expected manifest type for plain lossless FLAC (TIDAL BTS container).
+// manifestTypeBTS is the mime type for plain lossless FLAC (TIDAL BTS container).
 const manifestTypeBTS = "application/vnd.tidal.bts"
 
-// Client talks to a monochrome.tf-compatible instance of the hifi-api.
-// Zero value is not usable — use NewClient.
+// defaultUserAgent mimics a common desktop Chrome. Several community mirrors
+// sit behind Cloudflare and 403 requests from Go's default `Go-http-client/1.1`
+// UA — this gets us through.
+const defaultUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+// Client talks to one or more monochrome.tf-compatible hifi-api instances.
+// Multiple base URLs are tried in order — backends get TIDAL-banned regularly,
+// so the monochrome.tf website itself juggles ~10 mirrors. Zero value is not
+// usable — use NewClient.
 type Client struct {
-	baseURL string
-	http    *http.Client
+	baseURLs  []string
+	http      *http.Client
+	userAgent string
 }
 
-// NewClient returns a client pointing at baseURL (e.g. "https://api.monochrome.tf").
-// timeout bounds individual HTTP requests; use >= 60s to accommodate the ~10MB
-// CDN stream requests.
-func NewClient(baseURL string, timeout time.Duration) *Client {
+// NewClient returns a client with failover across baseURLs. Hosts are tried in
+// order per request; the first to return a valid response wins. Empty strings
+// are filtered; trailing slashes trimmed. timeout bounds each individual HTTP
+// request — use >= 60s to accommodate CDN FLAC downloads.
+func NewClient(baseURLs []string, timeout time.Duration) *Client {
+	cleaned := make([]string, 0, len(baseURLs))
+	for _, u := range baseURLs {
+		u = strings.TrimRight(strings.TrimSpace(u), "/")
+		if u != "" {
+			cleaned = append(cleaned, u)
+		}
+	}
 	return &Client{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		http:    &http.Client{Timeout: timeout},
+		baseURLs:  cleaned,
+		http:      &http.Client{Timeout: timeout},
+		userAgent: defaultUserAgent,
 	}
 }
 
-// TrackMatch is a normalized catalog hit returned by Search*.
+// Hosts returns the configured base URLs (for logging).
+func (c *Client) Hosts() []string {
+	out := make([]string, len(c.baseURLs))
+	copy(out, c.baseURLs)
+	return out
+}
+
+// TrackMatch is a normalized catalog hit returned by Search.
 type TrackMatch struct {
 	TidalID     int
 	ISRC        string
@@ -52,7 +76,7 @@ type TrackMatch struct {
 	Quality     string // upstream audioQuality: HI_RES_LOSSLESS, LOSSLESS, HIGH, LOW
 }
 
-// StreamInfo describes a resolved, signed CDN URL for the actual audio bytes.
+// StreamInfo describes a resolved, signed CDN URL for the audio bytes.
 type StreamInfo struct {
 	URL      string
 	Quality  string // quality upstream actually served — may be below what was requested
@@ -71,29 +95,23 @@ func (c *Client) Search(ctx context.Context, query string, limit int) ([]TrackMa
 	if limit <= 0 || limit > 100 {
 		limit = 25
 	}
-	return c.doSearch(ctx, url.Values{
+	q := url.Values{
 		"s":     {query},
 		"limit": {fmt.Sprintf("%d", limit)},
+	}
+	return tryAllHosts(c.baseURLs, func(base string) ([]TrackMatch, error) {
+		return c.searchOne(ctx, base, q)
 	})
 }
 
-func (c *Client) doSearch(ctx context.Context, q url.Values) ([]TrackMatch, error) {
-	u := c.baseURL + "/search/?" + q.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+func (c *Client) searchOne(ctx context.Context, base string, q url.Values) ([]TrackMatch, error) {
+	u := base + "/search/?" + q.Encode()
+	body, err := c.fetchJSON(ctx, u)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("search request: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("search failed: status %d: %s", resp.StatusCode, string(body))
-	}
 	var parsed searchResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(body, &parsed); err != nil {
 		return nil, fmt.Errorf("decode search response: %w", err)
 	}
 	matches := make([]TrackMatch, 0, len(parsed.Data.Items))
@@ -147,22 +165,19 @@ func (c *Client) GetStreamInfo(ctx context.Context, tidalID int, quality string)
 	if quality == "" {
 		quality = QualityLossless
 	}
-	u := fmt.Sprintf("%s/track/?id=%d&quality=%s", c.baseURL, tidalID, url.QueryEscape(quality))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	return tryAllHosts(c.baseURLs, func(base string) (*StreamInfo, error) {
+		return c.streamOne(ctx, base, tidalID, quality)
+	})
+}
+
+func (c *Client) streamOne(ctx context.Context, base string, tidalID int, quality string) (*StreamInfo, error) {
+	u := fmt.Sprintf("%s/track/?id=%d&quality=%s", base, tidalID, url.QueryEscape(quality))
+	body, err := c.fetchJSON(ctx, u)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("track request: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("track fetch failed: status %d: %s", resp.StatusCode, string(body))
-	}
 	var parsed playbackResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.Unmarshal(body, &parsed); err != nil {
 		return nil, fmt.Errorf("decode playback response: %w", err)
 	}
 	if parsed.Data.ManifestMimeType != manifestTypeBTS {
@@ -203,6 +218,75 @@ type manifestContent struct {
 	Codecs         string   `json:"codecs"`
 	EncryptionType string   `json:"encryptionType"`
 	URLs           []string `json:"urls"`
+}
+
+// fetchJSON GETs u, validates status, and detects FastAPI-style
+// `{"detail":"..."}` upstream errors that come back with HTTP 200 (common when
+// a monochrome mirror's TIDAL account is banned — it still serves 200 but
+// returns no data). Returns the raw JSON body for caller-side decoding.
+func (c *Client) fetchJSON(ctx context.Context, u string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, truncate(body, 200))
+	}
+	if detail := upstreamDetail(body); detail != "" {
+		return nil, fmt.Errorf("upstream error: %s", detail)
+	}
+	return body, nil
+}
+
+// upstreamDetail returns the `detail` field from a FastAPI-style error body, or
+// "" if the response contains real `data`.
+func upstreamDetail(body []byte) string {
+	var probe struct {
+		Detail string          `json:"detail"`
+		Data   json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return ""
+	}
+	if probe.Detail != "" && len(probe.Data) == 0 {
+		return probe.Detail
+	}
+	return ""
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}
+
+// tryAllHosts runs fn against each base in turn and returns the first success.
+// If every host fails, a single error aggregating them all is returned.
+func tryAllHosts[T any](bases []string, fn func(base string) (T, error)) (T, error) {
+	var zero T
+	if len(bases) == 0 {
+		return zero, fmt.Errorf("no monochrome backends configured")
+	}
+	errs := make([]string, 0, len(bases))
+	for _, base := range bases {
+		result, err := fn(base)
+		if err == nil {
+			return result, nil
+		}
+		errs = append(errs, fmt.Sprintf("%s: %v", base, err))
+	}
+	return zero, fmt.Errorf("all backends failed: %s", strings.Join(errs, "; "))
 }
 
 // Download streams streamURL to destPath. On any error the partial file is removed.

--- a/backend/monochrome/client.go
+++ b/backend/monochrome/client.go
@@ -1,0 +1,232 @@
+package monochrome
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// Quality levels accepted by the upstream /track/ endpoint.
+const (
+	QualityHiRes    = "HI_RES_LOSSLESS"
+	QualityLossless = "LOSSLESS"
+	QualityHigh     = "HIGH"
+	QualityLow      = "LOW"
+)
+
+// expected manifest type for plain lossless FLAC (TIDAL BTS container).
+const manifestTypeBTS = "application/vnd.tidal.bts"
+
+// Client talks to a monochrome.tf-compatible instance of the hifi-api.
+// Zero value is not usable — use NewClient.
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+// NewClient returns a client pointing at baseURL (e.g. "https://api.monochrome.tf").
+// timeout bounds individual HTTP requests; use >= 60s to accommodate the ~10MB
+// CDN stream requests.
+func NewClient(baseURL string, timeout time.Duration) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		http:    &http.Client{Timeout: timeout},
+	}
+}
+
+// TrackMatch is a normalized catalog hit returned by Search*.
+type TrackMatch struct {
+	TidalID     int
+	ISRC        string
+	Title       string
+	Artists     []string
+	Album       string
+	DurationSec int
+	Quality     string // upstream audioQuality: HI_RES_LOSSLESS, LOSSLESS, HIGH, LOW
+}
+
+// StreamInfo describes a resolved, signed CDN URL for the actual audio bytes.
+type StreamInfo struct {
+	URL      string
+	Quality  string // quality upstream actually served — may be below what was requested
+	MimeType string
+	Codec    string
+}
+
+// SearchByISRC looks up the TIDAL catalog by ISRC and returns zero or more matches.
+func (c *Client) SearchByISRC(ctx context.Context, isrc string) ([]TrackMatch, error) {
+	if strings.TrimSpace(isrc) == "" {
+		return nil, fmt.Errorf("empty ISRC")
+	}
+	return c.doSearch(ctx, url.Values{"i": {isrc}, "limit": {"5"}})
+}
+
+func (c *Client) doSearch(ctx context.Context, q url.Values) ([]TrackMatch, error) {
+	u := c.baseURL + "/search/?" + q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("search failed: status %d: %s", resp.StatusCode, string(body))
+	}
+	var parsed searchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode search response: %w", err)
+	}
+	matches := make([]TrackMatch, 0, len(parsed.Data.Items))
+	for _, it := range parsed.Data.Items {
+		artists := make([]string, 0, len(it.Artists))
+		for _, a := range it.Artists {
+			artists = append(artists, a.Name)
+		}
+		matches = append(matches, TrackMatch{
+			TidalID:     it.ID,
+			ISRC:        it.ISRC,
+			Title:       it.Title,
+			Artists:     artists,
+			Album:       it.Album.Title,
+			DurationSec: it.Duration,
+			Quality:     it.AudioQuality,
+		})
+	}
+	return matches, nil
+}
+
+type searchResponse struct {
+	Data struct {
+		Items []struct {
+			ID           int    `json:"id"`
+			Title        string `json:"title"`
+			Duration     int    `json:"duration"`
+			ISRC         string `json:"isrc"`
+			AudioQuality string `json:"audioQuality"`
+			Artists      []struct {
+				Name string `json:"name"`
+			} `json:"artists"`
+			Album struct {
+				Title string `json:"title"`
+			} `json:"album"`
+		} `json:"items"`
+	} `json:"data"`
+}
+
+// GetStreamInfo resolves a tidal track ID into a signed CDN URL. quality is one
+// of the Quality* constants; if upstream can't deliver the requested tier it
+// silently downgrades — the returned StreamInfo.Quality reflects what was
+// actually served.
+//
+// Errors on DRM-protected / Atmos / MQA responses (DASH manifests, non-NONE
+// encryption) — caller should fall back to another download source.
+func (c *Client) GetStreamInfo(ctx context.Context, tidalID int, quality string) (*StreamInfo, error) {
+	if tidalID <= 0 {
+		return nil, fmt.Errorf("invalid tidal id: %d", tidalID)
+	}
+	if quality == "" {
+		quality = QualityLossless
+	}
+	u := fmt.Sprintf("%s/track/?id=%d&quality=%s", c.baseURL, tidalID, url.QueryEscape(quality))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("track request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("track fetch failed: status %d: %s", resp.StatusCode, string(body))
+	}
+	var parsed playbackResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode playback response: %w", err)
+	}
+	if parsed.Data.ManifestMimeType != manifestTypeBTS {
+		return nil, fmt.Errorf("unsupported manifest type %q (DRM/DASH not supported)", parsed.Data.ManifestMimeType)
+	}
+	raw, err := base64.StdEncoding.DecodeString(parsed.Data.Manifest)
+	if err != nil {
+		return nil, fmt.Errorf("base64 decode manifest: %w", err)
+	}
+	var manifest manifestContent
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return nil, fmt.Errorf("decode manifest json: %w", err)
+	}
+	if manifest.EncryptionType != "" && !strings.EqualFold(manifest.EncryptionType, "NONE") {
+		return nil, fmt.Errorf("encrypted stream (%s) not supported", manifest.EncryptionType)
+	}
+	if len(manifest.URLs) == 0 {
+		return nil, fmt.Errorf("manifest has no URLs")
+	}
+	return &StreamInfo{
+		URL:      manifest.URLs[0],
+		Quality:  parsed.Data.AudioQuality,
+		MimeType: manifest.MimeType,
+		Codec:    manifest.Codecs,
+	}, nil
+}
+
+type playbackResponse struct {
+	Data struct {
+		AudioQuality     string `json:"audioQuality"`
+		ManifestMimeType string `json:"manifestMimeType"`
+		Manifest         string `json:"manifest"`
+	} `json:"data"`
+}
+
+type manifestContent struct {
+	MimeType       string   `json:"mimeType"`
+	Codecs         string   `json:"codecs"`
+	EncryptionType string   `json:"encryptionType"`
+	URLs           []string `json:"urls"`
+}
+
+// Download streams streamURL to destPath. On any error the partial file is removed.
+func (c *Client) Download(ctx context.Context, streamURL, destPath string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, streamURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("stream request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("stream download failed: status %d", resp.StatusCode)
+	}
+	f, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	n, copyErr := io.Copy(f, resp.Body)
+	closeErr := f.Close()
+	if copyErr != nil {
+		os.Remove(destPath)
+		return fmt.Errorf("copy stream: %w", copyErr)
+	}
+	if closeErr != nil {
+		os.Remove(destPath)
+		return fmt.Errorf("close dest file: %w", closeErr)
+	}
+	if n == 0 {
+		os.Remove(destPath)
+		return fmt.Errorf("empty stream body")
+	}
+	return nil
+}

--- a/backend/monochrome/client_test.go
+++ b/backend/monochrome/client_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -17,7 +18,7 @@ func newTestClient(t *testing.T, handler http.Handler) (*Client, *httptest.Serve
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
-	return NewClient(srv.URL, 5*time.Second), srv
+	return NewClient([]string{srv.URL}, 5*time.Second), srv
 }
 
 func TestSearch_ParsesCanonicalResponse(t *testing.T) {
@@ -59,8 +60,6 @@ func TestSearch_ParsesCanonicalResponse(t *testing.T) {
 	if gotPath != "/search/" {
 		t.Errorf("path: got %q, want /search/", gotPath)
 	}
-	// Free-text param is `s=`; the API rejects `i=` (ISRC) despite what the
-	// community docs suggest.
 	if !strings.Contains(gotQuery, "s=") {
 		t.Errorf("query must use s= param: got %q", gotQuery)
 	}
@@ -86,7 +85,7 @@ func TestSearch_ParsesCanonicalResponse(t *testing.T) {
 }
 
 func TestSearch_EmptyQueryRejected(t *testing.T) {
-	c := NewClient("http://example.invalid", time.Second)
+	c := NewClient([]string{"http://example.invalid"}, time.Second)
 	if _, err := c.Search(context.Background(), "", 10); err == nil {
 		t.Fatal("expected error for empty query")
 	}
@@ -119,22 +118,67 @@ func TestSearch_HTTPError(t *testing.T) {
 	}
 }
 
-func TestSearch_UpstreamAPIErrorSurfaces(t *testing.T) {
-	// The real service frequently returns 200 with `{"detail":"Upstream API error"}`
-	// when TIDAL has banned the backend account. Our client treats this as a
-	// successful-but-empty search (no items), which lets the caller fall back
-	// gracefully. Callers that need to know this happened should check for
-	// zero results.
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestSearch_UpstreamAPIErrorTriggersFailover(t *testing.T) {
+	// Monochrome mirrors return HTTP 200 with `{"detail":"Upstream API error"}`
+	// when the backend's TIDAL account is banned. Our client must detect this
+	// and fail over to the next configured host — which is the whole point of
+	// multi-backend support.
+	brokenHits := int32(0)
+	broken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&brokenHits, 1)
 		fmt.Fprint(w, `{"detail":"Upstream API error"}`)
-	})
-	c, _ := newTestClient(t, handler)
+	}))
+	t.Cleanup(broken.Close)
+
+	healthyHits := int32(0)
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&healthyHits, 1)
+		fmt.Fprint(w, `{"data":{"items":[{"id":1,"title":"ok","duration":30,"isrc":"X","audioQuality":"LOSSLESS","artists":[{"name":"A"}],"album":{"title":"B"}}]}}`)
+	}))
+	t.Cleanup(healthy.Close)
+
+	c := NewClient([]string{broken.URL, healthy.URL}, 5*time.Second)
 	matches, err := c.Search(context.Background(), "anything", 10)
 	if err != nil {
 		t.Fatalf("Search: %v", err)
 	}
-	if len(matches) != 0 {
-		t.Errorf("expected 0 matches when upstream reports error, got %d", len(matches))
+	if len(matches) != 1 || matches[0].Title != "ok" {
+		t.Fatalf("expected 1 match from healthy host, got %+v", matches)
+	}
+	if atomic.LoadInt32(&brokenHits) != 1 || atomic.LoadInt32(&healthyHits) != 1 {
+		t.Errorf("expected both hosts hit once: broken=%d healthy=%d",
+			atomic.LoadInt32(&brokenHits), atomic.LoadInt32(&healthyHits))
+	}
+}
+
+func TestSearch_AllHostsFailAggregates(t *testing.T) {
+	a := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"detail":"Upstream API error"}`)
+	}))
+	t.Cleanup(a.Close)
+	b := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(b.Close)
+
+	c := NewClient([]string{a.URL, b.URL}, 5*time.Second)
+	_, err := c.Search(context.Background(), "anything", 10)
+	if err == nil {
+		t.Fatal("expected aggregated error when all hosts fail")
+	}
+	if !strings.Contains(err.Error(), "all backends failed") {
+		t.Errorf("error should mention 'all backends failed': %v", err)
+	}
+}
+
+func TestNewClient_TrimsAndFiltersBaseURLs(t *testing.T) {
+	c := NewClient([]string{"  https://a.example.com/  ", "", "https://b.example.com"}, time.Second)
+	hosts := c.Hosts()
+	if len(hosts) != 2 {
+		t.Fatalf("expected 2 hosts, got %d: %v", len(hosts), hosts)
+	}
+	if hosts[0] != "https://a.example.com" || hosts[1] != "https://b.example.com" {
+		t.Errorf("hosts wrong: %+v", hosts)
 	}
 }
 
@@ -173,6 +217,31 @@ func TestGetStreamInfo_DecodesBase64Manifest(t *testing.T) {
 	}
 }
 
+func TestGetStreamInfo_FailsOverBetweenHosts(t *testing.T) {
+	// First host: upstream error. Second host: valid manifest. Expect success
+	// and the second URL to be returned.
+	broken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"detail":"Upstream API error"}`)
+	}))
+	t.Cleanup(broken.Close)
+
+	manifestJSON := `{"mimeType":"audio/flac","codecs":"flac","encryptionType":"NONE","urls":["https://cdn.example.com/good.flac"]}`
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"data":{"audioQuality":"LOSSLESS","manifestMimeType":"application/vnd.tidal.bts","manifest":%q}}`,
+			base64.StdEncoding.EncodeToString([]byte(manifestJSON)))
+	}))
+	t.Cleanup(healthy.Close)
+
+	c := NewClient([]string{broken.URL, healthy.URL}, 5*time.Second)
+	info, err := c.GetStreamInfo(context.Background(), 42, QualityLossless)
+	if err != nil {
+		t.Fatalf("GetStreamInfo: %v", err)
+	}
+	if info.URL != "https://cdn.example.com/good.flac" {
+		t.Errorf("expected URL from healthy host, got %q", info.URL)
+	}
+}
+
 func TestGetStreamInfo_RejectsDASHManifest(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"data":{"manifestMimeType":"application/dash+xml","manifest":"PHhtbD4="}}`)
@@ -202,7 +271,7 @@ func TestGetStreamInfo_RejectsEncryptedStream(t *testing.T) {
 }
 
 func TestGetStreamInfo_RejectsInvalidID(t *testing.T) {
-	c := NewClient("http://example.invalid", time.Second)
+	c := NewClient([]string{"http://example.invalid"}, time.Second)
 	if _, err := c.GetStreamInfo(context.Background(), 0, QualityLossless); err == nil {
 		t.Fatal("expected error on id=0")
 	}

--- a/backend/monochrome/client_test.go
+++ b/backend/monochrome/client_test.go
@@ -20,20 +20,24 @@ func newTestClient(t *testing.T, handler http.Handler) (*Client, *httptest.Serve
 	return NewClient(srv.URL, 5*time.Second), srv
 }
 
-func TestSearchByISRC_ParsesCanonicalResponse(t *testing.T) {
+func TestSearch_ParsesCanonicalResponse(t *testing.T) {
+	// Shape modeled after a real response from api.monochrome.tf (fields
+	// abbreviated). Both "artist" (singular) and "artists" (plural) are
+	// returned upstream; we rely on the plural form.
 	const canonicalBody = `{
-		"version": "2.10",
+		"version": "2.5",
 		"data": {
-			"limit": 5,
+			"limit": 25,
 			"offset": 0,
 			"totalNumberOfItems": 1,
 			"items": [{
-				"id": 77640691,
+				"id": 36737274,
 				"title": "Bohemian Rhapsody",
 				"duration": 354,
-				"isrc": "GBUM71029600",
-				"audioQuality": "HI_RES_LOSSLESS",
-				"artists": [{"id": 1, "name": "Queen"}],
+				"isrc": "GBUM71029604",
+				"audioQuality": "LOSSLESS",
+				"artist": {"id": 8992, "name": "Queen"},
+				"artists": [{"id": 8992, "name": "Queen", "type": "MAIN"}],
 				"album": {"id": 2, "title": "A Night at the Opera"}
 			}]
 		}
@@ -48,24 +52,29 @@ func TestSearchByISRC_ParsesCanonicalResponse(t *testing.T) {
 	})
 	c, _ := newTestClient(t, handler)
 
-	matches, err := c.SearchByISRC(context.Background(), "GBUM71029600")
+	matches, err := c.Search(context.Background(), "Bohemian Rhapsody Queen", 25)
 	if err != nil {
-		t.Fatalf("SearchByISRC: %v", err)
+		t.Fatalf("Search: %v", err)
 	}
 	if gotPath != "/search/" {
 		t.Errorf("path: got %q, want /search/", gotPath)
 	}
-	if !strings.Contains(gotQuery, "i=GBUM71029600") {
-		t.Errorf("query must contain ISRC param: got %q", gotQuery)
+	// Free-text param is `s=`; the API rejects `i=` (ISRC) despite what the
+	// community docs suggest.
+	if !strings.Contains(gotQuery, "s=") {
+		t.Errorf("query must use s= param: got %q", gotQuery)
+	}
+	if strings.Contains(gotQuery, "i=") {
+		t.Errorf("query must NOT use i= param (rejected by upstream): got %q", gotQuery)
 	}
 	if len(matches) != 1 {
 		t.Fatalf("matches: got %d, want 1", len(matches))
 	}
 	m := matches[0]
-	if m.TidalID != 77640691 || m.ISRC != "GBUM71029600" || m.Title != "Bohemian Rhapsody" {
+	if m.TidalID != 36737274 || m.ISRC != "GBUM71029604" || m.Title != "Bohemian Rhapsody" {
 		t.Errorf("match fields wrong: %+v", m)
 	}
-	if m.DurationSec != 354 || m.Quality != "HI_RES_LOSSLESS" {
+	if m.DurationSec != 354 || m.Quality != "LOSSLESS" {
 		t.Errorf("match duration/quality wrong: %+v", m)
 	}
 	if len(m.Artists) != 1 || m.Artists[0] != "Queen" {
@@ -76,37 +85,56 @@ func TestSearchByISRC_ParsesCanonicalResponse(t *testing.T) {
 	}
 }
 
-func TestSearchByISRC_EmptyISRCRejected(t *testing.T) {
+func TestSearch_EmptyQueryRejected(t *testing.T) {
 	c := NewClient("http://example.invalid", time.Second)
-	if _, err := c.SearchByISRC(context.Background(), ""); err == nil {
-		t.Fatal("expected error for empty ISRC")
+	if _, err := c.Search(context.Background(), "", 10); err == nil {
+		t.Fatal("expected error for empty query")
 	}
-	if _, err := c.SearchByISRC(context.Background(), "   "); err == nil {
-		t.Fatal("expected error for whitespace-only ISRC")
+	if _, err := c.Search(context.Background(), "   ", 10); err == nil {
+		t.Fatal("expected error for whitespace-only query")
 	}
 }
 
-func TestSearchByISRC_NoMatches(t *testing.T) {
+func TestSearch_NoMatches(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"data":{"items":[]}}`)
 	})
 	c, _ := newTestClient(t, handler)
-	matches, err := c.SearchByISRC(context.Background(), "ZZZZ00000000")
+	matches, err := c.Search(context.Background(), "zzznonexistentxxx", 10)
 	if err != nil {
-		t.Fatalf("SearchByISRC: %v", err)
+		t.Fatalf("Search: %v", err)
 	}
 	if len(matches) != 0 {
 		t.Errorf("expected 0 matches, got %d", len(matches))
 	}
 }
 
-func TestSearchByISRC_HTTPError(t *testing.T) {
+func TestSearch_HTTPError(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"detail":"Service Unavailable"}`, http.StatusServiceUnavailable)
 	})
 	c, _ := newTestClient(t, handler)
-	if _, err := c.SearchByISRC(context.Background(), "USRC11300135"); err == nil {
+	if _, err := c.Search(context.Background(), "anything", 10); err == nil {
 		t.Fatal("expected error on 503")
+	}
+}
+
+func TestSearch_UpstreamAPIErrorSurfaces(t *testing.T) {
+	// The real service frequently returns 200 with `{"detail":"Upstream API error"}`
+	// when TIDAL has banned the backend account. Our client treats this as a
+	// successful-but-empty search (no items), which lets the caller fall back
+	// gracefully. Callers that need to know this happened should check for
+	// zero results.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"detail":"Upstream API error"}`)
+	})
+	c, _ := newTestClient(t, handler)
+	matches, err := c.Search(context.Background(), "anything", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches when upstream reports error, got %d", len(matches))
 	}
 }
 

--- a/backend/monochrome/client_test.go
+++ b/backend/monochrome/client_test.go
@@ -1,0 +1,238 @@
+package monochrome
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewClient(srv.URL, 5*time.Second), srv
+}
+
+func TestSearchByISRC_ParsesCanonicalResponse(t *testing.T) {
+	const canonicalBody = `{
+		"version": "2.10",
+		"data": {
+			"limit": 5,
+			"offset": 0,
+			"totalNumberOfItems": 1,
+			"items": [{
+				"id": 77640691,
+				"title": "Bohemian Rhapsody",
+				"duration": 354,
+				"isrc": "GBUM71029600",
+				"audioQuality": "HI_RES_LOSSLESS",
+				"artists": [{"id": 1, "name": "Queen"}],
+				"album": {"id": 2, "title": "A Night at the Opera"}
+			}]
+		}
+	}`
+
+	var gotPath, gotQuery string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, canonicalBody)
+	})
+	c, _ := newTestClient(t, handler)
+
+	matches, err := c.SearchByISRC(context.Background(), "GBUM71029600")
+	if err != nil {
+		t.Fatalf("SearchByISRC: %v", err)
+	}
+	if gotPath != "/search/" {
+		t.Errorf("path: got %q, want /search/", gotPath)
+	}
+	if !strings.Contains(gotQuery, "i=GBUM71029600") {
+		t.Errorf("query must contain ISRC param: got %q", gotQuery)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("matches: got %d, want 1", len(matches))
+	}
+	m := matches[0]
+	if m.TidalID != 77640691 || m.ISRC != "GBUM71029600" || m.Title != "Bohemian Rhapsody" {
+		t.Errorf("match fields wrong: %+v", m)
+	}
+	if m.DurationSec != 354 || m.Quality != "HI_RES_LOSSLESS" {
+		t.Errorf("match duration/quality wrong: %+v", m)
+	}
+	if len(m.Artists) != 1 || m.Artists[0] != "Queen" {
+		t.Errorf("artists wrong: %+v", m.Artists)
+	}
+	if m.Album != "A Night at the Opera" {
+		t.Errorf("album wrong: %q", m.Album)
+	}
+}
+
+func TestSearchByISRC_EmptyISRCRejected(t *testing.T) {
+	c := NewClient("http://example.invalid", time.Second)
+	if _, err := c.SearchByISRC(context.Background(), ""); err == nil {
+		t.Fatal("expected error for empty ISRC")
+	}
+	if _, err := c.SearchByISRC(context.Background(), "   "); err == nil {
+		t.Fatal("expected error for whitespace-only ISRC")
+	}
+}
+
+func TestSearchByISRC_NoMatches(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data":{"items":[]}}`)
+	})
+	c, _ := newTestClient(t, handler)
+	matches, err := c.SearchByISRC(context.Background(), "ZZZZ00000000")
+	if err != nil {
+		t.Fatalf("SearchByISRC: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches, got %d", len(matches))
+	}
+}
+
+func TestSearchByISRC_HTTPError(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"detail":"Service Unavailable"}`, http.StatusServiceUnavailable)
+	})
+	c, _ := newTestClient(t, handler)
+	if _, err := c.SearchByISRC(context.Background(), "USRC11300135"); err == nil {
+		t.Fatal("expected error on 503")
+	}
+}
+
+func TestGetStreamInfo_DecodesBase64Manifest(t *testing.T) {
+	manifestJSON := `{"mimeType":"audio/flac","codecs":"flac","encryptionType":"NONE","urls":["https://cdn.example.com/stream.flac?sig=abc"]}`
+	body := fmt.Sprintf(`{
+		"data": {
+			"trackId": 77640691,
+			"audioQuality": "HI_RES_LOSSLESS",
+			"bitDepth": 24,
+			"sampleRate": 96000,
+			"manifestMimeType": "application/vnd.tidal.bts",
+			"manifest": %q
+		}
+	}`, base64.StdEncoding.EncodeToString([]byte(manifestJSON)))
+
+	var gotQuery string
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		fmt.Fprint(w, body)
+	})
+	c, _ := newTestClient(t, handler)
+
+	info, err := c.GetStreamInfo(context.Background(), 77640691, QualityHiRes)
+	if err != nil {
+		t.Fatalf("GetStreamInfo: %v", err)
+	}
+	if info.URL != "https://cdn.example.com/stream.flac?sig=abc" {
+		t.Errorf("URL wrong: %q", info.URL)
+	}
+	if info.Quality != "HI_RES_LOSSLESS" || info.Codec != "flac" || info.MimeType != "audio/flac" {
+		t.Errorf("info fields wrong: %+v", info)
+	}
+	if !strings.Contains(gotQuery, "id=77640691") || !strings.Contains(gotQuery, "quality=HI_RES_LOSSLESS") {
+		t.Errorf("query wrong: %q", gotQuery)
+	}
+}
+
+func TestGetStreamInfo_RejectsDASHManifest(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data":{"manifestMimeType":"application/dash+xml","manifest":"PHhtbD4="}}`)
+	})
+	c, _ := newTestClient(t, handler)
+	_, err := c.GetStreamInfo(context.Background(), 1, QualityLossless)
+	if err == nil {
+		t.Fatal("expected error on DASH manifest")
+	}
+	if !strings.Contains(err.Error(), "unsupported manifest") {
+		t.Errorf("error message should mention unsupported manifest: %v", err)
+	}
+}
+
+func TestGetStreamInfo_RejectsEncryptedStream(t *testing.T) {
+	manifestJSON := `{"mimeType":"audio/mp4","codecs":"mp4a.40.2","encryptionType":"OLD_AES","urls":["x"]}`
+	body := fmt.Sprintf(`{"data":{"manifestMimeType":"application/vnd.tidal.bts","manifest":%q}}`,
+		base64.StdEncoding.EncodeToString([]byte(manifestJSON)))
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	})
+	c, _ := newTestClient(t, handler)
+	_, err := c.GetStreamInfo(context.Background(), 1, QualityLossless)
+	if err == nil || !strings.Contains(err.Error(), "encrypted") {
+		t.Fatalf("expected encryption error, got %v", err)
+	}
+}
+
+func TestGetStreamInfo_RejectsInvalidID(t *testing.T) {
+	c := NewClient("http://example.invalid", time.Second)
+	if _, err := c.GetStreamInfo(context.Background(), 0, QualityLossless); err == nil {
+		t.Fatal("expected error on id=0")
+	}
+	if _, err := c.GetStreamInfo(context.Background(), -5, QualityLossless); err == nil {
+		t.Fatal("expected error on negative id")
+	}
+}
+
+func TestDownload_StreamsToFile(t *testing.T) {
+	const payload = "FLACFAKEBYTES12345"
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/flac")
+		fmt.Fprint(w, payload)
+	})
+	c, srv := newTestClient(t, handler)
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.flac")
+	if err := c.Download(context.Background(), srv.URL+"/stream", dest); err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(got) != payload {
+		t.Errorf("payload mismatch: got %q want %q", string(got), payload)
+	}
+}
+
+func TestDownload_CleansPartialOnError(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "gone", http.StatusGone)
+	})
+	c, srv := newTestClient(t, handler)
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.flac")
+	if err := c.Download(context.Background(), srv.URL+"/stream", dest); err == nil {
+		t.Fatal("expected error on 410")
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Errorf("expected dest file to not exist after error, stat err: %v", err)
+	}
+}
+
+func TestDownload_RejectsEmptyBody(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	c, srv := newTestClient(t, handler)
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.flac")
+	if err := c.Download(context.Background(), srv.URL+"/stream", dest); err == nil {
+		t.Fatal("expected error on empty body")
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Errorf("expected dest file to not exist after empty body, stat err: %v", err)
+	}
+}

--- a/backend/spotify/handlers.go
+++ b/backend/spotify/handlers.go
@@ -57,8 +57,7 @@ func (h *Handlers) UpdateConfig(c *gin.Context) {
 		return
 	}
 
-	// Get the user ID from the context (set by auth middleware)
-	userID, exists := c.Get("userID")
+	userID, exists := c.Get("user_id")
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": gin.H{"code": "unauthorized", "message": "user not authenticated"}})
 		return
@@ -85,7 +84,7 @@ func (h *Handlers) ExchangeToken(c *gin.Context) {
 		return
 	}
 
-	userID, exists := c.Get("userID")
+	userID, exists := c.Get("user_id")
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": gin.H{"code": "unauthorized", "message": "user not authenticated"}})
 		return

--- a/backend/spotify/handlers.go
+++ b/backend/spotify/handlers.go
@@ -1,0 +1,157 @@
+package spotify
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Handlers struct {
+	manager *Manager
+}
+
+func NewHandlers(manager *Manager) *Handlers {
+	return &Handlers{manager: manager}
+}
+
+func (h *Handlers) GetConfig(c *gin.Context) {
+	cfg, err := h.manager.GetSyncConfig(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "internal_error", "message": err.Error()}})
+		return
+	}
+
+	clientID := h.manager.GetClientID()
+
+	if cfg == nil {
+		c.JSON(http.StatusOK, gin.H{
+			"configured": false,
+			"enabled":    false,
+			"client_id":  clientID,
+		})
+		return
+	}
+
+	hasToken := cfg.AccessToken != nil && *cfg.AccessToken != ""
+
+	c.JSON(http.StatusOK, gin.H{
+		"configured":              hasToken,
+		"enabled":                 cfg.Enabled,
+		"owner_user_id":           cfg.OwnerUserID,
+		"liked_songs_playlist_id": cfg.LikedSongsPlaylistID,
+		"last_sync_at":            cfg.LastSyncAt,
+		"client_id":               clientID,
+	})
+}
+
+type UpdateConfigRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+func (h *Handlers) UpdateConfig(c *gin.Context) {
+	var req UpdateConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_request", "message": err.Error()}})
+		return
+	}
+
+	// Get the user ID from the context (set by auth middleware)
+	userID, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": gin.H{"code": "unauthorized", "message": "user not authenticated"}})
+		return
+	}
+
+	if err := h.manager.SaveSyncConfig(c.Request.Context(), userID.(string), req.Enabled); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "internal_error", "message": err.Error()}})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "config updated"})
+}
+
+type TokenExchangeRequest struct {
+	Code         string `json:"code" binding:"required"`
+	CodeVerifier string `json:"code_verifier" binding:"required"`
+	RedirectURI  string `json:"redirect_uri" binding:"required"`
+}
+
+func (h *Handlers) ExchangeToken(c *gin.Context) {
+	var req TokenExchangeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "invalid_request", "message": err.Error()}})
+		return
+	}
+
+	userID, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": gin.H{"code": "unauthorized", "message": "user not authenticated"}})
+		return
+	}
+
+	if err := h.manager.ExchangeCodeForToken(c.Request.Context(), req.Code, req.CodeVerifier, req.RedirectURI, userID.(string)); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"code": "token_exchange_failed", "message": err.Error()}})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "connected to Spotify"})
+}
+
+func (h *Handlers) Disconnect(c *gin.Context) {
+	if err := h.manager.Disconnect(c.Request.Context()); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "internal_error", "message": err.Error()}})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "disconnected from Spotify"})
+}
+
+func (h *Handlers) TriggerSync(c *gin.Context) {
+	go func() {
+		if err := h.manager.SyncLikes(context.Background()); err != nil {
+			fmt.Printf("[Spotify] Manual sync failed: %v\n", err)
+		}
+	}()
+
+	c.JSON(http.StatusAccepted, gin.H{"message": "sync triggered"})
+}
+
+func (h *Handlers) GetHistory(c *gin.Context) {
+	history, err := h.manager.GetSyncHistory(c.Request.Context(), 20)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "internal_error", "message": err.Error()}})
+		return
+	}
+
+	if history == nil {
+		history = []*SyncHistory{}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"history": history})
+}
+
+func (h *Handlers) GetPlaylists(c *gin.Context) {
+	playlists, err := h.manager.FetchUserPlaylists(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "internal_error", "message": err.Error()}})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"playlists": playlists})
+}
+
+func (h *Handlers) GetSyncedPlaylists(c *gin.Context) {
+	playlists, err := h.manager.GetSyncedPlaylists(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": gin.H{"code": "internal_error", "message": err.Error()}})
+		return
+	}
+
+	if playlists == nil {
+		playlists = []*SyncedPlaylist{}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"playlists": playlists})
+}

--- a/backend/spotify/manager.go
+++ b/backend/spotify/manager.go
@@ -631,10 +631,12 @@ func (m *Manager) GetSyncedPlaylists(ctx context.Context) ([]*SyncedPlaylist, er
 	return m.repo.GetSyncedPlaylists(ctx)
 }
 
-// Disconnect removes the Spotify connection
 func (m *Manager) Disconnect(ctx context.Context) error {
 	cfg, err := m.repo.GetSyncConfig(ctx)
-	if err != nil || cfg == nil {
+	if err != nil {
+		return fmt.Errorf("failed to get sync config: %w", err)
+	}
+	if cfg == nil {
 		return nil
 	}
 

--- a/backend/spotify/manager.go
+++ b/backend/spotify/manager.go
@@ -646,29 +646,36 @@ func getArtistName(st SpotifyTrack) string {
 }
 
 // tryMonochromeDownload attempts to resolve st to a TIDAL FLAC via monochrome
-// and saves it into tmpDir. Duration is used to guard against wrong-version
-// matches (clean edits, remasters) when multiple ISRC hits are returned.
+// and saves it into tmpDir.
+//
+// The upstream API has no direct ISRC lookup, so we run a free-text search for
+// "artist title" and require an exact ISRC match among the results. No ISRC
+// match → fall back to yt-dlp. Duration is a secondary sanity check against
+// mislabeled catalog entries.
 func (m *Manager) tryMonochromeDownload(ctx context.Context, tmpDir string, st SpotifyTrack) error {
-	matches, err := m.monochrome.SearchByISRC(ctx, st.ExternalIDs.ISRC)
+	query := strings.TrimSpace(fmt.Sprintf("%s %s", getArtistName(st), st.Name))
+	if query == "" {
+		return fmt.Errorf("empty search query")
+	}
+	matches, err := m.monochrome.Search(ctx, query, 50)
 	if err != nil {
 		return fmt.Errorf("search: %w", err)
 	}
-	if len(matches) == 0 {
-		return fmt.Errorf("no ISRC match")
+
+	var best *monochrome.TrackMatch
+	for i := range matches {
+		if strings.EqualFold(matches[i].ISRC, st.ExternalIDs.ISRC) {
+			best = &matches[i]
+			break
+		}
+	}
+	if best == nil {
+		return fmt.Errorf("no ISRC match for %s in %d results", st.ExternalIDs.ISRC, len(matches))
 	}
 
 	spotifyDurSec := st.DurationMs / 1000
-	best := matches[0]
-	bestDiff := absInt(best.DurationSec - spotifyDurSec)
-	for _, cand := range matches[1:] {
-		d := absInt(cand.DurationSec - spotifyDurSec)
-		if d < bestDiff {
-			best = cand
-			bestDiff = d
-		}
-	}
-	if spotifyDurSec > 0 && bestDiff > 5 {
-		return fmt.Errorf("duration mismatch: tidal=%ds spotify=%ds", best.DurationSec, spotifyDurSec)
+	if spotifyDurSec > 0 && absInt(best.DurationSec-spotifyDurSec) > 5 {
+		return fmt.Errorf("ISRC match but duration mismatch: tidal=%ds spotify=%ds", best.DurationSec, spotifyDurSec)
 	}
 
 	info, err := m.monochrome.GetStreamInfo(ctx, best.TidalID, monochrome.QualityHiRes)

--- a/backend/spotify/manager.go
+++ b/backend/spotify/manager.go
@@ -675,6 +675,12 @@ func (m *Manager) tryMonochromeDownload(ctx context.Context, tmpDir string, st S
 	if err != nil {
 		return fmt.Errorf("stream info: %w", err)
 	}
+	// Guard against silent downgrades to AAC when the backend account has been
+	// restricted — we only want this path for actual lossless FLAC; anything
+	// else should fall back to yt-dlp.
+	if !strings.EqualFold(info.Codec, "flac") {
+		return fmt.Errorf("unexpected codec %q (quality=%s); want flac", info.Codec, info.Quality)
+	}
 
 	safeName := sanitizeFilename(st.Name)
 	if safeName == "" {

--- a/backend/spotify/manager.go
+++ b/backend/spotify/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/faraz525/home-music-server/backend/internal/media/metadata"
 	imodels "github.com/faraz525/home-music-server/backend/internal/models"
 	"github.com/faraz525/home-music-server/backend/internal/storage"
+	"github.com/faraz525/home-music-server/backend/monochrome"
 	"github.com/faraz525/home-music-server/backend/playlists"
 	"github.com/faraz525/home-music-server/backend/tracks"
 	"github.com/faraz525/home-music-server/backend/utils"
@@ -36,9 +37,12 @@ type Manager struct {
 	playlistsManager *playlists.Manager
 	dataDir          string
 	clientID         string
+	monochrome       *monochrome.Client // optional; nil = disabled, falls straight to yt-dlp
 	syncMutex        sync.Mutex
 }
 
+// NewManager builds a Spotify sync manager. monoClient may be nil — when set,
+// downloads try monochrome.tf (TIDAL FLAC) first and fall back to yt-dlp.
 func NewManager(
 	repo *Repository,
 	tracksRepo *tracks.Repository,
@@ -46,6 +50,7 @@ func NewManager(
 	extractor metadata.Extractor,
 	pm *playlists.Manager,
 	dataDir string,
+	monoClient *monochrome.Client,
 ) *Manager {
 	clientID := os.Getenv("SPOTIFY_CLIENT_ID")
 	return &Manager{
@@ -56,6 +61,7 @@ func NewManager(
 		playlistsManager: pm,
 		dataDir:          dataDir,
 		clientID:         clientID,
+		monochrome:       monoClient,
 	}
 }
 
@@ -231,10 +237,13 @@ type SpotifyTrack struct {
 	Album struct {
 		Name string `json:"name"`
 	} `json:"album"`
-	DurationMs int `json:"duration_ms"`
+	DurationMs   int `json:"duration_ms"`
 	ExternalURLs struct {
 		Spotify string `json:"spotify"`
 	} `json:"external_urls"`
+	ExternalIDs struct {
+		ISRC string `json:"isrc"`
+	} `json:"external_ids"`
 }
 
 // SpotifyPlaylist represents a playlist from Spotify API
@@ -518,22 +527,32 @@ func (m *Manager) downloadAndImportTrack(ctx context.Context, userID string, st 
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Use yt-dlp to download from Spotify (requires spotify-dl or similar setup)
-	// Fall back to searching YouTube for the track
-	searchQuery := fmt.Sprintf("%s %s", getArtistName(st), st.Name)
-	outputTemplate := filepath.Join(tmpDir, "%(title)s.%(ext)s")
+	// Prefer monochrome (TIDAL FLAC) when configured and ISRC is known.
+	// Any failure falls through to yt-dlp.
+	if m.monochrome != nil && st.ExternalIDs.ISRC != "" {
+		if err := m.tryMonochromeDownload(ctx, tmpDir, st); err != nil {
+			fmt.Printf("[Spotify] monochrome download failed for %s (ISRC %s): %v — falling back to yt-dlp\n",
+				st.Name, st.ExternalIDs.ISRC, err)
+		}
+	}
 
-	cmd := exec.CommandContext(ctx, "yt-dlp",
-		"--default-search", "ytsearch1",
-		"-x", "--audio-format", "mp3",
-		"--audio-quality", "0",
-		"-o", outputTemplate,
-		searchQuery,
-	)
+	// yt-dlp fallback only runs if monochrome produced no file.
+	if existing, _ := os.ReadDir(tmpDir); len(existing) == 0 {
+		searchQuery := fmt.Sprintf("%s %s", getArtistName(st), st.Name)
+		outputTemplate := filepath.Join(tmpDir, "%(title)s.%(ext)s")
 
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("download failed: %v, output: %s", err, string(output))
+		cmd := exec.CommandContext(ctx, "yt-dlp",
+			"--default-search", "ytsearch1",
+			"-x", "--audio-format", "mp3",
+			"--audio-quality", "0",
+			"-o", outputTemplate,
+			searchQuery,
+		)
+
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return "", fmt.Errorf("download failed: %v, output: %s", err, string(output))
+		}
 	}
 
 	files, err := os.ReadDir(tmpDir)
@@ -624,6 +643,78 @@ func getArtistName(st SpotifyTrack) string {
 		return strings.Join(names, ", ")
 	}
 	return ""
+}
+
+// tryMonochromeDownload attempts to resolve st to a TIDAL FLAC via monochrome
+// and saves it into tmpDir. Duration is used to guard against wrong-version
+// matches (clean edits, remasters) when multiple ISRC hits are returned.
+func (m *Manager) tryMonochromeDownload(ctx context.Context, tmpDir string, st SpotifyTrack) error {
+	matches, err := m.monochrome.SearchByISRC(ctx, st.ExternalIDs.ISRC)
+	if err != nil {
+		return fmt.Errorf("search: %w", err)
+	}
+	if len(matches) == 0 {
+		return fmt.Errorf("no ISRC match")
+	}
+
+	spotifyDurSec := st.DurationMs / 1000
+	best := matches[0]
+	bestDiff := absInt(best.DurationSec - spotifyDurSec)
+	for _, cand := range matches[1:] {
+		d := absInt(cand.DurationSec - spotifyDurSec)
+		if d < bestDiff {
+			best = cand
+			bestDiff = d
+		}
+	}
+	if spotifyDurSec > 0 && bestDiff > 5 {
+		return fmt.Errorf("duration mismatch: tidal=%ds spotify=%ds", best.DurationSec, spotifyDurSec)
+	}
+
+	info, err := m.monochrome.GetStreamInfo(ctx, best.TidalID, monochrome.QualityHiRes)
+	if err != nil {
+		return fmt.Errorf("stream info: %w", err)
+	}
+
+	safeName := sanitizeFilename(st.Name)
+	if safeName == "" {
+		safeName = fmt.Sprintf("track_%d", best.TidalID)
+	}
+	destPath := filepath.Join(tmpDir, safeName+".flac")
+	if err := m.monochrome.Download(ctx, info.URL, destPath); err != nil {
+		return fmt.Errorf("download: %w", err)
+	}
+
+	fmt.Printf("[Spotify] monochrome: %s — tidal=%d quality=%s\n", st.Name, best.TidalID, info.Quality)
+	return nil
+}
+
+// sanitizeFilename strips filesystem-reserved chars and control bytes; caps at 100 runes.
+func sanitizeFilename(s string) string {
+	s = strings.TrimSpace(s)
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r == '/' || r == '\\' || r == ':' || r == '*' || r == '?' || r == '"' || r == '<' || r == '>' || r == '|':
+			b.WriteByte('_')
+		case r < 0x20:
+			// skip control chars
+		default:
+			b.WriteRune(r)
+		}
+	}
+	out := b.String()
+	if len(out) > 100 {
+		out = out[:100]
+	}
+	return out
+}
+
+func absInt(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
 }
 
 // GetSyncedPlaylists returns all synced Spotify playlists

--- a/backend/spotify/manager.go
+++ b/backend/spotify/manager.go
@@ -1,0 +1,647 @@
+package spotify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/faraz525/home-music-server/backend/internal/media/metadata"
+	imodels "github.com/faraz525/home-music-server/backend/internal/models"
+	"github.com/faraz525/home-music-server/backend/internal/storage"
+	"github.com/faraz525/home-music-server/backend/playlists"
+	"github.com/faraz525/home-music-server/backend/tracks"
+	"github.com/faraz525/home-music-server/backend/utils"
+)
+
+const (
+	SpotifyAuthURL  = "https://accounts.spotify.com/authorize"
+	SpotifyTokenURL = "https://accounts.spotify.com/api/token"
+	SpotifyAPIURL   = "https://api.spotify.com/v1"
+)
+
+type Manager struct {
+	repo             *Repository
+	tracksRepo       *tracks.Repository
+	storage          storage.Storage
+	extractor        metadata.Extractor
+	playlistsManager *playlists.Manager
+	dataDir          string
+	clientID         string
+	syncMutex        sync.Mutex
+}
+
+func NewManager(
+	repo *Repository,
+	tracksRepo *tracks.Repository,
+	storage storage.Storage,
+	extractor metadata.Extractor,
+	pm *playlists.Manager,
+	dataDir string,
+) *Manager {
+	clientID := os.Getenv("SPOTIFY_CLIENT_ID")
+	return &Manager{
+		repo:             repo,
+		tracksRepo:       tracksRepo,
+		storage:          storage,
+		extractor:        extractor,
+		playlistsManager: pm,
+		dataDir:          dataDir,
+		clientID:         clientID,
+	}
+}
+
+func (m *Manager) GetClientID() string {
+	return m.clientID
+}
+
+func (m *Manager) GetSyncConfig(ctx context.Context) (*SyncConfig, error) {
+	return m.repo.GetSyncConfig(ctx)
+}
+
+func (m *Manager) SaveSyncConfig(ctx context.Context, ownerUserID string, enabled bool) error {
+	cfg := &SyncConfig{
+		OwnerUserID: ownerUserID,
+		Enabled:     enabled,
+	}
+
+	existing, _ := m.repo.GetSyncConfig(ctx)
+	if existing != nil {
+		cfg.AccessToken = existing.AccessToken
+		cfg.RefreshToken = existing.RefreshToken
+		cfg.TokenExpiresAt = existing.TokenExpiresAt
+		cfg.LikedSongsPlaylistID = existing.LikedSongsPlaylistID
+	}
+
+	return m.repo.UpsertSyncConfig(ctx, cfg)
+}
+
+func (m *Manager) GetSyncHistory(ctx context.Context, limit int) ([]*SyncHistory, error) {
+	if limit <= 0 || limit > 50 {
+		limit = 10
+	}
+	return m.repo.GetSyncHistory(ctx, limit)
+}
+
+// ExchangeCodeForToken exchanges an authorization code for access and refresh tokens using PKCE
+func (m *Manager) ExchangeCodeForToken(ctx context.Context, code, codeVerifier, redirectURI, ownerUserID string) error {
+	data := url.Values{}
+	data.Set("grant_type", "authorization_code")
+	data.Set("code", code)
+	data.Set("redirect_uri", redirectURI)
+	data.Set("client_id", m.clientID)
+	data.Set("code_verifier", codeVerifier)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", SpotifyTokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to exchange token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+		TokenType    string `json:"token_type"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+
+	cfg := &SyncConfig{
+		AccessToken:    &tokenResp.AccessToken,
+		RefreshToken:   &tokenResp.RefreshToken,
+		TokenExpiresAt: &expiresAt,
+		OwnerUserID:    ownerUserID,
+		Enabled:        false, // User must explicitly enable
+	}
+
+	// Preserve existing playlist ID if config exists
+	existing, _ := m.repo.GetSyncConfig(ctx)
+	if existing != nil {
+		cfg.LikedSongsPlaylistID = existing.LikedSongsPlaylistID
+		cfg.Enabled = existing.Enabled
+	}
+
+	return m.repo.UpsertSyncConfig(ctx, cfg)
+}
+
+// RefreshAccessToken refreshes the access token using the refresh token
+func (m *Manager) RefreshAccessToken(ctx context.Context) error {
+	cfg, err := m.repo.GetSyncConfig(ctx)
+	if err != nil || cfg == nil || cfg.RefreshToken == nil {
+		return fmt.Errorf("no refresh token available")
+	}
+
+	data := url.Values{}
+	data.Set("grant_type", "refresh_token")
+	data.Set("refresh_token", *cfg.RefreshToken)
+	data.Set("client_id", m.clientID)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", SpotifyTokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to refresh token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("token refresh failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return fmt.Errorf("failed to parse refresh response: %w", err)
+	}
+
+	expiresAt := time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+
+	// If no new refresh token is provided, keep the old one
+	refreshToken := *cfg.RefreshToken
+	if tokenResp.RefreshToken != "" {
+		refreshToken = tokenResp.RefreshToken
+	}
+
+	return m.repo.UpdateTokens(ctx, tokenResp.AccessToken, refreshToken, expiresAt)
+}
+
+// getValidToken returns a valid access token, refreshing if necessary
+func (m *Manager) getValidToken(ctx context.Context) (string, error) {
+	cfg, err := m.repo.GetSyncConfig(ctx)
+	if err != nil || cfg == nil {
+		return "", fmt.Errorf("spotify not configured")
+	}
+
+	if cfg.AccessToken == nil || *cfg.AccessToken == "" {
+		return "", fmt.Errorf("no access token")
+	}
+
+	// Refresh if token expires in the next 5 minutes
+	if cfg.TokenExpiresAt != nil && time.Until(*cfg.TokenExpiresAt) < 5*time.Minute {
+		if err := m.RefreshAccessToken(ctx); err != nil {
+			return "", fmt.Errorf("failed to refresh token: %w", err)
+		}
+		// Reload config after refresh
+		cfg, _ = m.repo.GetSyncConfig(ctx)
+	}
+
+	return *cfg.AccessToken, nil
+}
+
+// SpotifyTrack represents a track from Spotify API
+type SpotifyTrack struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Artists []struct {
+		Name string `json:"name"`
+	} `json:"artists"`
+	Album struct {
+		Name string `json:"name"`
+	} `json:"album"`
+	DurationMs int `json:"duration_ms"`
+	ExternalURLs struct {
+		Spotify string `json:"spotify"`
+	} `json:"external_urls"`
+}
+
+// SpotifyPlaylist represents a playlist from Spotify API
+type SpotifyPlaylist struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Tracks struct {
+		Total int `json:"total"`
+	} `json:"tracks"`
+}
+
+// FetchLikedSongs fetches the user's liked songs from Spotify
+func (m *Manager) FetchLikedSongs(ctx context.Context, limit, offset int) ([]SpotifyTrack, int, error) {
+	token, err := m.getValidToken(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	url := fmt.Sprintf("%s/me/tracks?limit=%d&offset=%d", SpotifyAPIURL, limit, offset)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, 0, fmt.Errorf("spotify API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Items []struct {
+			Track SpotifyTrack `json:"track"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, 0, err
+	}
+
+	tracks := make([]SpotifyTrack, len(result.Items))
+	for i, item := range result.Items {
+		tracks[i] = item.Track
+	}
+
+	return tracks, result.Total, nil
+}
+
+// FetchUserPlaylists fetches the user's playlists from Spotify
+func (m *Manager) FetchUserPlaylists(ctx context.Context) ([]SpotifyPlaylist, error) {
+	token, err := m.getValidToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var allPlaylists []SpotifyPlaylist
+	offset := 0
+	limit := 50
+
+	for {
+		url := fmt.Sprintf("%s/me/playlists?limit=%d&offset=%d", SpotifyAPIURL, limit, offset)
+		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		client := &http.Client{Timeout: 30 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("spotify API error %d: %s", resp.StatusCode, string(body))
+		}
+
+		var result struct {
+			Items []SpotifyPlaylist `json:"items"`
+			Total int               `json:"total"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			resp.Body.Close()
+			return nil, err
+		}
+		resp.Body.Close()
+
+		allPlaylists = append(allPlaylists, result.Items...)
+
+		if len(allPlaylists) >= result.Total {
+			break
+		}
+		offset += limit
+	}
+
+	return allPlaylists, nil
+}
+
+// FetchPlaylistTracks fetches tracks from a specific playlist
+func (m *Manager) FetchPlaylistTracks(ctx context.Context, playlistID string, limit, offset int) ([]SpotifyTrack, int, error) {
+	token, err := m.getValidToken(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	url := fmt.Sprintf("%s/playlists/%s/tracks?limit=%d&offset=%d", SpotifyAPIURL, playlistID, limit, offset)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, 0, fmt.Errorf("spotify API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Items []struct {
+			Track SpotifyTrack `json:"track"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, 0, err
+	}
+
+	tracks := make([]SpotifyTrack, 0, len(result.Items))
+	for _, item := range result.Items {
+		// Skip nil tracks (can happen with local files)
+		if item.Track.ID != "" {
+			tracks = append(tracks, item.Track)
+		}
+	}
+
+	return tracks, result.Total, nil
+}
+
+func (m *Manager) SyncLikes(ctx context.Context) error {
+	if !m.syncMutex.TryLock() {
+		fmt.Println("[Spotify] Sync already in progress, skipping")
+		return nil
+	}
+	defer m.syncMutex.Unlock()
+
+	fmt.Println("[Spotify] Starting sync...")
+	started := time.Now()
+
+	cfg, err := m.repo.GetSyncConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get sync config: %w", err)
+	}
+
+	if cfg == nil {
+		fmt.Println("[Spotify] Sync not configured, skipping")
+		return nil
+	}
+
+	if !cfg.Enabled {
+		fmt.Println("[Spotify] Sync disabled, skipping")
+		return nil
+	}
+
+	if cfg.AccessToken == nil || *cfg.AccessToken == "" {
+		return fmt.Errorf("access token not configured")
+	}
+
+	playlistID, err := m.ensureLikedSongsPlaylist(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to ensure playlist: %w", err)
+	}
+
+	tracksAdded := 0
+	tracksSkipped := 0
+	var trackIDs []string
+
+	// Fetch liked songs with pagination
+	offset := 0
+	limit := 50
+	for {
+		spotifyTracks, total, err := m.FetchLikedSongs(ctx, limit, offset)
+		if err != nil {
+			errMsg := fmt.Sprintf("failed to fetch liked songs: %v", err)
+			m.repo.RecordSync(ctx, started, tracksAdded, tracksSkipped, &errMsg)
+			return fmt.Errorf(errMsg)
+		}
+
+		for _, st := range spotifyTracks {
+			synced, err := m.repo.IsSpotifyTrackSynced(ctx, st.ID)
+			if err != nil {
+				fmt.Printf("[Spotify] Error checking if track synced: %v\n", err)
+			}
+			if synced {
+				fmt.Printf("[Spotify] Skipping already synced track: %s\n", st.Name)
+				tracksSkipped++
+				continue
+			}
+
+			trackID, err := m.downloadAndImportTrack(ctx, cfg.OwnerUserID, st)
+			if err != nil {
+				fmt.Printf("[Spotify] Skipping track %s: %v\n", st.Name, err)
+				tracksSkipped++
+				continue
+			}
+
+			if err := m.repo.RecordSyncedTrack(ctx, st.ID, trackID); err != nil {
+				fmt.Printf("[Spotify] Warning: failed to record synced track: %v\n", err)
+			}
+
+			trackIDs = append(trackIDs, trackID)
+			tracksAdded++
+			fmt.Printf("[Spotify] Imported: %s - %s\n", getArtistName(st), st.Name)
+		}
+
+		offset += limit
+		if offset >= total {
+			break
+		}
+	}
+
+	if len(trackIDs) > 0 {
+		req := &imodels.AddTracksToPlaylistRequest{TrackIDs: trackIDs}
+		if err := m.playlistsManager.AddTracksToPlaylist(playlistID, cfg.OwnerUserID, req); err != nil {
+			fmt.Printf("[Spotify] Warning: failed to add tracks to playlist: %v\n", err)
+		}
+	}
+
+	m.repo.UpdateLastSync(ctx)
+	m.repo.RecordSync(ctx, started, tracksAdded, tracksSkipped, nil)
+
+	fmt.Printf("[Spotify] Sync complete: %d added, %d skipped\n", tracksAdded, tracksSkipped)
+	return nil
+}
+
+func (m *Manager) ensureLikedSongsPlaylist(ctx context.Context, cfg *SyncConfig) (string, error) {
+	if cfg.LikedSongsPlaylistID != nil && *cfg.LikedSongsPlaylistID != "" {
+		return *cfg.LikedSongsPlaylistID, nil
+	}
+
+	desc := "Auto-synced from Spotify liked songs"
+	isPublic := false
+	req := &imodels.CreatePlaylistRequest{
+		Name:        "Spotify Liked Songs",
+		Description: &desc,
+		IsPublic:    &isPublic,
+	}
+
+	playlist, err := m.playlistsManager.CreatePlaylist(cfg.OwnerUserID, req)
+	if err != nil {
+		return "", err
+	}
+
+	if err := m.repo.UpdateLikedSongsPlaylistID(ctx, playlist.ID); err != nil {
+		fmt.Printf("[Spotify] Warning: failed to update playlist ID in config: %v\n", err)
+	}
+
+	fmt.Printf("[Spotify] Created playlist: %s (%s)\n", playlist.Name, playlist.ID)
+	return playlist.ID, nil
+}
+
+func (m *Manager) downloadAndImportTrack(ctx context.Context, userID string, st SpotifyTrack) (string, error) {
+	tmpDir := filepath.Join(m.dataDir, "tmp", fmt.Sprintf("spotify-%s", st.ID))
+	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Use yt-dlp to download from Spotify (requires spotify-dl or similar setup)
+	// Fall back to searching YouTube for the track
+	searchQuery := fmt.Sprintf("%s %s", getArtistName(st), st.Name)
+	outputTemplate := filepath.Join(tmpDir, "%(title)s.%(ext)s")
+
+	cmd := exec.CommandContext(ctx, "yt-dlp",
+		"--default-search", "ytsearch1",
+		"-x", "--audio-format", "mp3",
+		"--audio-quality", "0",
+		"-o", outputTemplate,
+		searchQuery,
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("download failed: %v, output: %s", err, string(output))
+	}
+
+	files, err := os.ReadDir(tmpDir)
+	if err != nil || len(files) == 0 {
+		return "", fmt.Errorf("no files downloaded")
+	}
+
+	downloadedFile := filepath.Join(tmpDir, files[0].Name())
+
+	file, err := os.Open(downloadedFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to open downloaded file: %w", err)
+	}
+	defer file.Close()
+
+	filename := files[0].Name()
+	trackID := utils.GenerateTrackID()
+
+	relPath, size, contentType, err := m.storage.Save(ctx, userID, trackID, filename, file)
+	if err != nil {
+		return "", fmt.Errorf("failed to save file: %w", err)
+	}
+
+	fullPath, _ := m.storage.ResolveFullPath(relPath)
+	md, err := m.extractor.Extract(ctx, fullPath)
+	if err != nil {
+		fmt.Printf("[Spotify] Warning: metadata extraction failed for %s: %v\n", filename, err)
+		md = &metadata.AudioMetadata{}
+	}
+
+	track := &imodels.Track{
+		OwnerUserID:      userID,
+		OriginalFilename: filename,
+		ContentType:      contentType,
+		SizeBytes:        size,
+		FilePath:         relPath,
+		CreatedAt:        utils.Now(),
+		UpdatedAt:        utils.Now(),
+	}
+
+	// Prefer Spotify metadata over extracted metadata
+	title := st.Name
+	track.Title = &title
+
+	artist := getArtistName(st)
+	if artist != "" {
+		track.Artist = &artist
+	} else if md.Artist != nil {
+		track.Artist = md.Artist
+	}
+
+	album := st.Album.Name
+	if album != "" {
+		track.Album = &album
+	} else if md.Album != nil {
+		track.Album = md.Album
+	}
+
+	duration := float64(st.DurationMs) / 1000
+	if duration > 0 {
+		track.DurationSeconds = &duration
+	} else if md.DurationSeconds > 0 {
+		track.DurationSeconds = &md.DurationSeconds
+	}
+
+	if md.SampleRate != nil {
+		track.SampleRate = md.SampleRate
+	}
+	if md.Bitrate != nil {
+		track.Bitrate = md.Bitrate
+	}
+
+	track, err = m.tracksRepo.CreateTrack(ctx, track)
+	if err != nil {
+		m.storage.Delete(ctx, relPath)
+		return "", fmt.Errorf("failed to create track record: %w", err)
+	}
+
+	return track.ID, nil
+}
+
+func getArtistName(st SpotifyTrack) string {
+	if len(st.Artists) > 0 {
+		names := make([]string, len(st.Artists))
+		for i, a := range st.Artists {
+			names[i] = a.Name
+		}
+		return strings.Join(names, ", ")
+	}
+	return ""
+}
+
+// GetSyncedPlaylists returns all synced Spotify playlists
+func (m *Manager) GetSyncedPlaylists(ctx context.Context) ([]*SyncedPlaylist, error) {
+	return m.repo.GetSyncedPlaylists(ctx)
+}
+
+// Disconnect removes the Spotify connection
+func (m *Manager) Disconnect(ctx context.Context) error {
+	cfg, err := m.repo.GetSyncConfig(ctx)
+	if err != nil || cfg == nil {
+		return nil
+	}
+
+	cfg.AccessToken = nil
+	cfg.RefreshToken = nil
+	cfg.TokenExpiresAt = nil
+	cfg.Enabled = false
+
+	return m.repo.UpsertSyncConfig(ctx, cfg)
+}

--- a/backend/spotify/repository.go
+++ b/backend/spotify/repository.go
@@ -1,0 +1,268 @@
+package spotify
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/faraz525/home-music-server/backend/internal/db"
+	"github.com/faraz525/home-music-server/backend/utils"
+)
+
+type Repository struct {
+	db *db.DB
+}
+
+func NewRepository(db *db.DB) *Repository {
+	return &Repository{db: db}
+}
+
+type SyncConfig struct {
+	ID                   int        `json:"id"`
+	AccessToken          *string    `json:"access_token,omitempty"`
+	RefreshToken         *string    `json:"refresh_token,omitempty"`
+	TokenExpiresAt       *time.Time `json:"token_expires_at,omitempty"`
+	OwnerUserID          string     `json:"owner_user_id"`
+	LikedSongsPlaylistID *string    `json:"liked_songs_playlist_id"`
+	Enabled              bool       `json:"enabled"`
+	LastSyncAt           *time.Time `json:"last_sync_at"`
+	CreatedAt            time.Time  `json:"created_at"`
+	UpdatedAt            time.Time  `json:"updated_at"`
+}
+
+func (r *Repository) GetSyncConfig(ctx context.Context) (*SyncConfig, error) {
+	var cfg SyncConfig
+	var accessToken, refreshToken, playlistID sql.NullString
+	var tokenExpiresAt, lastSyncAt sql.NullTime
+
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id, access_token, refresh_token, token_expires_at, owner_user_id, 
+                liked_songs_playlist_id, enabled, last_sync_at, created_at, updated_at
+         FROM spotify_sync_config WHERE id = 1`,
+	).Scan(&cfg.ID, &accessToken, &refreshToken, &tokenExpiresAt, &cfg.OwnerUserID,
+		&playlistID, &cfg.Enabled, &lastSyncAt, &cfg.CreatedAt, &cfg.UpdatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if accessToken.Valid {
+		cfg.AccessToken = &accessToken.String
+	}
+	if refreshToken.Valid {
+		cfg.RefreshToken = &refreshToken.String
+	}
+	if tokenExpiresAt.Valid {
+		cfg.TokenExpiresAt = &tokenExpiresAt.Time
+	}
+	if playlistID.Valid {
+		cfg.LikedSongsPlaylistID = &playlistID.String
+	}
+	if lastSyncAt.Valid {
+		cfg.LastSyncAt = &lastSyncAt.Time
+	}
+
+	return &cfg, nil
+}
+
+func (r *Repository) UpsertSyncConfig(ctx context.Context, cfg *SyncConfig) error {
+	now := time.Now()
+
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO spotify_sync_config (id, access_token, refresh_token, token_expires_at, owner_user_id, 
+                                          liked_songs_playlist_id, enabled, created_at, updated_at)
+         VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+            access_token = excluded.access_token,
+            refresh_token = excluded.refresh_token,
+            token_expires_at = excluded.token_expires_at,
+            owner_user_id = excluded.owner_user_id,
+            liked_songs_playlist_id = excluded.liked_songs_playlist_id,
+            enabled = excluded.enabled,
+            updated_at = excluded.updated_at`,
+		cfg.AccessToken, cfg.RefreshToken, cfg.TokenExpiresAt, cfg.OwnerUserID,
+		cfg.LikedSongsPlaylistID, cfg.Enabled, now, now,
+	)
+	return err
+}
+
+func (r *Repository) UpdateTokens(ctx context.Context, accessToken, refreshToken string, expiresAt time.Time) error {
+	now := time.Now()
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE spotify_sync_config SET access_token = ?, refresh_token = ?, token_expires_at = ?, updated_at = ? WHERE id = 1`,
+		accessToken, refreshToken, expiresAt, now,
+	)
+	return err
+}
+
+func (r *Repository) UpdateLastSync(ctx context.Context) error {
+	now := time.Now()
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE spotify_sync_config SET last_sync_at = ?, updated_at = ? WHERE id = 1`,
+		now, now,
+	)
+	return err
+}
+
+func (r *Repository) UpdateLikedSongsPlaylistID(ctx context.Context, playlistID string) error {
+	now := time.Now()
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE spotify_sync_config SET liked_songs_playlist_id = ?, updated_at = ? WHERE id = 1`,
+		playlistID, now,
+	)
+	return err
+}
+
+func (r *Repository) RecordSync(ctx context.Context, started time.Time, tracksAdded, tracksSkipped int, errMsg *string) error {
+	id := utils.GenerateID("sync")
+	now := time.Now()
+
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO spotify_sync_history (id, sync_started_at, sync_completed_at, tracks_added, tracks_skipped, error_message)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+		id, started, now, tracksAdded, tracksSkipped, errMsg,
+	)
+	return err
+}
+
+func (r *Repository) GetSyncHistory(ctx context.Context, limit int) ([]*SyncHistory, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, sync_started_at, sync_completed_at, tracks_added, tracks_skipped, error_message
+         FROM spotify_sync_history ORDER BY sync_started_at DESC LIMIT ?`,
+		limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var history []*SyncHistory
+	for rows.Next() {
+		var h SyncHistory
+		var completedAt sql.NullTime
+		var errMsg sql.NullString
+
+		err := rows.Scan(&h.ID, &h.StartedAt, &completedAt, &h.TracksAdded, &h.TracksSkipped, &errMsg)
+		if err != nil {
+			return nil, err
+		}
+
+		if completedAt.Valid {
+			h.CompletedAt = &completedAt.Time
+		}
+		if errMsg.Valid {
+			h.ErrorMessage = &errMsg.String
+		}
+
+		history = append(history, &h)
+	}
+
+	return history, rows.Err()
+}
+
+type SyncHistory struct {
+	ID            string     `json:"id"`
+	StartedAt     time.Time  `json:"started_at"`
+	CompletedAt   *time.Time `json:"completed_at,omitempty"`
+	TracksAdded   int        `json:"tracks_added"`
+	TracksSkipped int        `json:"tracks_skipped"`
+	ErrorMessage  *string    `json:"error_message,omitempty"`
+}
+
+func (r *Repository) IsSpotifyTrackSynced(ctx context.Context, spotifyID string) (bool, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM spotify_synced_tracks WHERE spotify_id = ?`,
+		spotifyID,
+	).Scan(&count)
+	return count > 0, err
+}
+
+func (r *Repository) RecordSyncedTrack(ctx context.Context, spotifyID, trackID string) error {
+	id := utils.GenerateID("spt")
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO spotify_synced_tracks (id, spotify_id, track_id, synced_at)
+         VALUES (?, ?, ?, ?)`,
+		id, spotifyID, trackID, time.Now(),
+	)
+	return err
+}
+
+// Synced playlist management
+type SyncedPlaylist struct {
+	ID                string     `json:"id"`
+	SpotifyPlaylistID string     `json:"spotify_playlist_id"`
+	LocalPlaylistID   string     `json:"local_playlist_id"`
+	Name              string     `json:"name"`
+	Enabled           bool       `json:"enabled"`
+	LastSyncAt        *time.Time `json:"last_sync_at,omitempty"`
+	CreatedAt         time.Time  `json:"created_at"`
+}
+
+func (r *Repository) GetSyncedPlaylists(ctx context.Context) ([]*SyncedPlaylist, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, spotify_playlist_id, local_playlist_id, name, enabled, last_sync_at, created_at
+         FROM spotify_synced_playlists ORDER BY name ASC`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var playlists []*SyncedPlaylist
+	for rows.Next() {
+		var p SyncedPlaylist
+		var lastSyncAt sql.NullTime
+
+		err := rows.Scan(&p.ID, &p.SpotifyPlaylistID, &p.LocalPlaylistID, &p.Name, &p.Enabled, &lastSyncAt, &p.CreatedAt)
+		if err != nil {
+			return nil, err
+		}
+
+		if lastSyncAt.Valid {
+			p.LastSyncAt = &lastSyncAt.Time
+		}
+
+		playlists = append(playlists, &p)
+	}
+
+	return playlists, rows.Err()
+}
+
+func (r *Repository) AddSyncedPlaylist(ctx context.Context, spotifyID, localID, name string) error {
+	id := utils.GenerateID("spp")
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO spotify_synced_playlists (id, spotify_playlist_id, local_playlist_id, name, enabled, created_at)
+         VALUES (?, ?, ?, ?, TRUE, ?)
+         ON CONFLICT(spotify_playlist_id) DO UPDATE SET name = excluded.name`,
+		id, spotifyID, localID, name, time.Now(),
+	)
+	return err
+}
+
+func (r *Repository) UpdateSyncedPlaylistLastSync(ctx context.Context, spotifyID string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE spotify_synced_playlists SET last_sync_at = ? WHERE spotify_playlist_id = ?`,
+		time.Now(), spotifyID,
+	)
+	return err
+}
+
+func (r *Repository) SetSyncedPlaylistEnabled(ctx context.Context, spotifyID string, enabled bool) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE spotify_synced_playlists SET enabled = ? WHERE spotify_playlist_id = ?`,
+		enabled, spotifyID,
+	)
+	return err
+}
+
+func (r *Repository) DeleteSyncedPlaylist(ctx context.Context, spotifyID string) error {
+	_, err := r.db.ExecContext(ctx,
+		`DELETE FROM spotify_synced_playlists WHERE spotify_playlist_id = ?`,
+		spotifyID,
+	)
+	return err
+}

--- a/backend/spotify/routes.go
+++ b/backend/spotify/routes.go
@@ -1,0 +1,23 @@
+package spotify
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func Routes(manager *Manager) func(*gin.RouterGroup) {
+	return func(rg *gin.RouterGroup) {
+		handlers := NewHandlers(manager)
+
+		sp := rg.Group("/spotify")
+		{
+			sp.GET("/config", handlers.GetConfig)
+			sp.PUT("/config", handlers.UpdateConfig)
+			sp.POST("/token", handlers.ExchangeToken)
+			sp.POST("/disconnect", handlers.Disconnect)
+			sp.POST("/sync", handlers.TriggerSync)
+			sp.GET("/history", handlers.GetHistory)
+			sp.GET("/playlists", handlers.GetPlaylists)
+			sp.GET("/synced-playlists", handlers.GetSyncedPlaylists)
+		}
+	}
+}

--- a/backend/spotify/ticker.go
+++ b/backend/spotify/ticker.go
@@ -1,0 +1,39 @@
+package spotify
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func StartSyncLoop(ctx context.Context, manager *Manager) {
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+
+	fmt.Println("[Spotify] Sync loop started (24h interval)")
+
+	initialDelay := time.NewTimer(2 * time.Minute)
+	defer initialDelay.Stop()
+
+	select {
+	case <-ctx.Done():
+		fmt.Println("[Spotify] Sync loop cancelled before initial run")
+		return
+	case <-initialDelay.C:
+		if err := manager.SyncLikes(ctx); err != nil {
+			fmt.Printf("[Spotify] Initial sync failed: %v\n", err)
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("[Spotify] Sync loop stopped")
+			return
+		case <-ticker.C:
+			if err := manager.SyncLikes(ctx); err != nil {
+				fmt.Printf("[Spotify] Scheduled sync failed: %v\n", err)
+			}
+		}
+	}
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { CommunityPage } from './pages/CommunityPage'
 import { UploadPage } from './pages/UploadPage'
 import { AdminPage } from './pages/AdminPage'
 import { SoundCloudPage } from './pages/SoundCloudPage'
+import { SpotifyPage } from './pages/SpotifyPage'
 import { NotFound } from './pages/NotFound'
 import { AuthProvider, useAuth } from './state/auth'
 
@@ -37,6 +38,7 @@ export default function App() {
           <Route path="/community" element={<CommunityPage />} />
           <Route path="/admin" element={<AdminPage />} />
           <Route path="/soundcloud" element={<SoundCloudPage />} />
+          <Route path="/spotify" element={<SpotifyPage />} />
         </Route>
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,5 +1,5 @@
 import { NavLink, Outlet, Link, useLocation } from 'react-router-dom'
-import { Library, LogOut, Settings, UploadCloud, Folder, Menu, X, FolderOpen, Globe, Disc, Cloud } from 'lucide-react'
+import { Library, LogOut, Settings, UploadCloud, Folder, Menu, X, FolderOpen, Globe, Disc, Cloud, Music2 } from 'lucide-react'
 import { useAuth } from '../../state/auth'
 import { PlayerBar } from '../player/PlayerBar'
 import { useCallback, useEffect, useState } from 'react'
@@ -103,6 +103,7 @@ export function Layout() {
             <>
               <NavItem to="/admin" label="Admin" icon={<Settings size={18} />} />
               <NavItem to="/soundcloud" label="SoundCloud" icon={<Cloud size={18} />} />
+              <NavItem to="/spotify" label="Spotify" icon={<Music2 size={18} />} />
             </>
           )}
 
@@ -187,6 +188,7 @@ export function Layout() {
               <>
                 <NavItem to="/admin" label="Admin" icon={<Settings size={18} />} />
                 <NavItem to="/soundcloud" label="SoundCloud" icon={<Cloud size={18} />} />
+                <NavItem to="/spotify" label="Spotify" icon={<Music2 size={18} />} />
               </>
             )}
 
@@ -292,6 +294,7 @@ function SidebarContent({ user, logout, onNavigate, crates, selectedCrateId }: {
           <>
             <NavItem to="/admin" label="Admin" icon={<Settings size={18} />} onClick={onNavigate} />
             <NavItem to="/soundcloud" label="SoundCloud" icon={<Cloud size={18} />} onClick={onNavigate} />
+            <NavItem to="/spotify" label="Spotify" icon={<Music2 size={18} />} onClick={onNavigate} />
           </>
         )}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -155,3 +155,48 @@ export const soundcloudApi = {
   getHistory: () =>
     api.get<{ history: SoundCloudSyncHistory[] }>('/api/soundcloud/history'),
 }
+
+// Spotify sync API
+export type SpotifyConfig = {
+  configured: boolean
+  enabled: boolean
+  owner_user_id?: string
+  liked_songs_playlist_id?: string
+  last_sync_at?: string
+  client_id?: string
+}
+
+export type SpotifySyncHistory = {
+  id: string
+  started_at: string
+  completed_at?: string
+  tracks_added: number
+  tracks_skipped: number
+  error_message?: string
+}
+
+export const spotifyApi = {
+  getConfig: () =>
+    api.get<SpotifyConfig>('/api/spotify/config'),
+
+  updateConfig: (data: { enabled: boolean }) =>
+    api.put('/api/spotify/config', data),
+
+  exchangeToken: (data: { code: string; code_verifier: string; redirect_uri: string }) =>
+    api.post('/api/spotify/token', data),
+
+  disconnect: () =>
+    api.post('/api/spotify/disconnect'),
+
+  triggerSync: () =>
+    api.post('/api/spotify/sync'),
+
+  getHistory: () =>
+    api.get<{ history: SpotifySyncHistory[] }>('/api/spotify/history'),
+
+  getPlaylists: () =>
+    api.get<{ playlists: Array<{ id: string; name: string; tracks: { total: number } }> }>('/api/spotify/playlists'),
+
+  getSyncedPlaylists: () =>
+    api.get<{ playlists: Array<{ id: string; spotify_playlist_id: string; local_playlist_id: string; name: string; enabled: boolean }> }>('/api/spotify/synced-playlists'),
+}

--- a/frontend/src/pages/SpotifyPage.tsx
+++ b/frontend/src/pages/SpotifyPage.tsx
@@ -5,7 +5,6 @@ import { useAuth } from '../state/auth'
 import { toast } from 'sonner'
 import { useSearchParams } from 'react-router-dom'
 
-// PKCE helpers
 function generateRandomString(length: number): string {
   const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
   const values = crypto.getRandomValues(new Uint8Array(length))
@@ -61,7 +60,6 @@ export function SpotifyPage() {
     }
   }, [])
 
-  // Handle OAuth callback
   useEffect(() => {
     const code = searchParams.get('code')
     const state = searchParams.get('state')
@@ -83,7 +81,6 @@ export function SpotifyPage() {
       } else if (!codeVerifier) {
         toast.error('Code verifier not found. Please try connecting again.')
       } else {
-        // Exchange code for token
         setConnecting(true)
         spotifyApi.exchangeToken({
           code,
@@ -104,7 +101,6 @@ export function SpotifyPage() {
           })
       }
 
-      // Clean up URL
       searchParams.delete('code')
       searchParams.delete('state')
       setSearchParams(searchParams)
@@ -125,7 +121,6 @@ export function SpotifyPage() {
     const state = generateRandomString(16)
     const codeChallenge = await generateCodeChallenge(codeVerifier)
 
-    // Store for later verification
     sessionStorage.setItem('spotify_code_verifier', codeVerifier)
     sessionStorage.setItem('spotify_auth_state', state)
 

--- a/frontend/src/pages/SpotifyPage.tsx
+++ b/frontend/src/pages/SpotifyPage.tsx
@@ -1,0 +1,420 @@
+import { useEffect, useState, useCallback } from 'react'
+import { Music2, RefreshCw, Check, X, Disc, History, AlertCircle, Link2, Unlink } from 'lucide-react'
+import { spotifyApi, SpotifyConfig, SpotifySyncHistory } from '../lib/api'
+import { useAuth } from '../state/auth'
+import { toast } from 'sonner'
+import { useSearchParams } from 'react-router-dom'
+
+// PKCE helpers
+function generateRandomString(length: number): string {
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  const values = crypto.getRandomValues(new Uint8Array(length))
+  return values.reduce((acc, x) => acc + possible[x % possible.length], '')
+}
+
+async function sha256(plain: string): Promise<ArrayBuffer> {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(plain)
+  return window.crypto.subtle.digest('SHA-256', data)
+}
+
+function base64encode(input: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(input)))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+}
+
+async function generateCodeChallenge(codeVerifier: string): Promise<string> {
+  const hashed = await sha256(codeVerifier)
+  return base64encode(hashed)
+}
+
+const SPOTIFY_AUTH_URL = 'https://accounts.spotify.com/authorize'
+const SPOTIFY_SCOPES = ['user-library-read', 'playlist-read-private', 'playlist-read-collaborative']
+
+export function SpotifyPage() {
+  const { user } = useAuth()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [config, setConfig] = useState<SpotifyConfig | null>(null)
+  const [history, setHistory] = useState<SpotifySyncHistory[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [syncing, setSyncing] = useState(false)
+  const [connecting, setConnecting] = useState(false)
+  const [enabled, setEnabled] = useState(false)
+
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [configRes, historyRes] = await Promise.all([
+        spotifyApi.getConfig(),
+        spotifyApi.getHistory(),
+      ])
+      setConfig(configRes.data)
+      setHistory(historyRes.data?.history || [])
+      setEnabled(configRes.data?.enabled || false)
+    } catch {
+      toast.error('Failed to load Spotify configuration')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Handle OAuth callback
+  useEffect(() => {
+    const code = searchParams.get('code')
+    const state = searchParams.get('state')
+    const error = searchParams.get('error')
+
+    if (error) {
+      toast.error(`Spotify authorization failed: ${error}`)
+      searchParams.delete('error')
+      setSearchParams(searchParams)
+      return
+    }
+
+    if (code && state) {
+      const storedState = sessionStorage.getItem('spotify_auth_state')
+      const codeVerifier = sessionStorage.getItem('spotify_code_verifier')
+
+      if (state !== storedState) {
+        toast.error('State mismatch. Please try connecting again.')
+      } else if (!codeVerifier) {
+        toast.error('Code verifier not found. Please try connecting again.')
+      } else {
+        // Exchange code for token
+        setConnecting(true)
+        spotifyApi.exchangeToken({
+          code,
+          code_verifier: codeVerifier,
+          redirect_uri: window.location.origin + '/spotify',
+        })
+          .then(() => {
+            toast.success('Connected to Spotify!')
+            sessionStorage.removeItem('spotify_auth_state')
+            sessionStorage.removeItem('spotify_code_verifier')
+            fetchData()
+          })
+          .catch(() => {
+            toast.error('Failed to connect to Spotify')
+          })
+          .finally(() => {
+            setConnecting(false)
+          })
+      }
+
+      // Clean up URL
+      searchParams.delete('code')
+      searchParams.delete('state')
+      setSearchParams(searchParams)
+    }
+  }, [searchParams, setSearchParams, fetchData])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  async function handleConnect() {
+    if (!config?.client_id) {
+      toast.error('Spotify client ID not configured on server')
+      return
+    }
+
+    const codeVerifier = generateRandomString(64)
+    const state = generateRandomString(16)
+    const codeChallenge = await generateCodeChallenge(codeVerifier)
+
+    // Store for later verification
+    sessionStorage.setItem('spotify_code_verifier', codeVerifier)
+    sessionStorage.setItem('spotify_auth_state', state)
+
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: config.client_id,
+      scope: SPOTIFY_SCOPES.join(' '),
+      redirect_uri: window.location.origin + '/spotify',
+      state: state,
+      code_challenge_method: 'S256',
+      code_challenge: codeChallenge,
+    })
+
+    window.location.href = `${SPOTIFY_AUTH_URL}?${params.toString()}`
+  }
+
+  async function handleDisconnect() {
+    try {
+      await spotifyApi.disconnect()
+      toast.success('Disconnected from Spotify')
+      fetchData()
+    } catch {
+      toast.error('Failed to disconnect')
+    }
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    try {
+      await spotifyApi.updateConfig({ enabled })
+      toast.success('Spotify configuration saved')
+      fetchData()
+    } catch {
+      toast.error('Failed to save configuration')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleSync() {
+    setSyncing(true)
+    try {
+      await spotifyApi.triggerSync()
+      toast.success('Sync started! Check back in a few minutes.')
+      setTimeout(fetchData, 5000)
+    } catch {
+      toast.error('Failed to trigger sync')
+    } finally {
+      setSyncing(false)
+    }
+  }
+
+  function formatDate(dateString?: string) {
+    if (!dateString) return 'Never'
+    return new Date(dateString).toLocaleString()
+  }
+
+  if (user?.role !== 'admin') {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-display font-bold text-crate-cream">Spotify Sync</h1>
+          <p className="text-crate-muted mt-1">Admin access required</p>
+        </div>
+        <div className="card p-8 text-center">
+          <AlertCircle size={48} className="mx-auto text-crate-subtle mb-4" />
+          <p className="text-crate-muted">Only admins can configure Spotify sync.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-display font-bold text-crate-cream">Spotify Sync</h1>
+        <p className="text-crate-muted mt-1">Auto-sync your Spotify liked songs to CrateDrop</p>
+      </div>
+
+      {loading || connecting ? (
+        <div className="flex items-center justify-center gap-3 py-12">
+          <Disc className="text-crate-amber vinyl-spinning" size={24} />
+          <span className="text-crate-muted">{connecting ? 'Connecting to Spotify...' : 'Loading...'}</span>
+        </div>
+      ) : (
+        <>
+          {/* Status Card */}
+          <div className="card p-5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-4">
+                <div className="p-3 rounded-xl bg-green-500/10">
+                  <Music2 size={24} className="text-green-500" />
+                </div>
+                <div>
+                  <div className="text-sm text-crate-muted">Status</div>
+                  <div className="flex items-center gap-2">
+                    {config?.configured ? (
+                      <>
+                        {config?.enabled ? (
+                          <span className="flex items-center gap-1.5 text-green-500">
+                            <Check size={16} /> Active (auto-sync on)
+                          </span>
+                        ) : (
+                          <span className="flex items-center gap-1.5 text-crate-amber">
+                            <Check size={16} /> Connected (auto-sync off)
+                          </span>
+                        )}
+                      </>
+                    ) : (
+                      <span className="text-crate-muted">Not connected</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                {config?.configured && (
+                  <>
+                    <button
+                      onClick={handleDisconnect}
+                      className="btn-ghost flex items-center gap-2 text-crate-muted hover:text-red-500"
+                    >
+                      <Unlink size={16} />
+                      Disconnect
+                    </button>
+                    <button
+                      onClick={handleSync}
+                      disabled={syncing}
+                      className="btn-secondary flex items-center gap-2"
+                    >
+                      <RefreshCw size={16} className={syncing ? 'animate-spin' : ''} />
+                      {syncing ? 'Syncing...' : 'Sync Now'}
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+            {config?.last_sync_at && (
+              <div className="mt-4 pt-4 border-t border-crate-border">
+                <span className="text-sm text-crate-muted">
+                  Last sync: {formatDate(config.last_sync_at)}
+                </span>
+              </div>
+            )}
+          </div>
+
+          {/* Connect or Configuration Card */}
+          <div className="card overflow-hidden">
+            <div className="p-5 border-b border-crate-border">
+              <h2 className="text-lg font-display font-semibold text-crate-cream">
+                {config?.configured ? 'Configuration' : 'Connect to Spotify'}
+              </h2>
+            </div>
+            <div className="p-5 space-y-4">
+              {!config?.configured ? (
+                <div className="text-center py-6">
+                  <Music2 size={48} className="mx-auto text-green-500 mb-4" />
+                  <p className="text-crate-muted mb-6">
+                    Connect your Spotify account to sync your liked songs automatically.
+                  </p>
+                  {!config?.client_id ? (
+                    <div className="p-4 bg-crate-amber/10 border border-crate-amber/20 rounded-xl text-sm text-crate-amber">
+                      <AlertCircle size={16} className="inline mr-2" />
+                      SPOTIFY_CLIENT_ID environment variable not set on server
+                    </div>
+                  ) : (
+                    <button
+                      onClick={handleConnect}
+                      className="btn-primary bg-green-600 hover:bg-green-700 flex items-center gap-2 mx-auto"
+                    >
+                      <Link2 size={16} />
+                      Connect with Spotify
+                    </button>
+                  )}
+                </div>
+              ) : (
+                <>
+                  <div className="flex items-center gap-3">
+                    <button
+                      onClick={() => setEnabled(!enabled)}
+                      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                        enabled ? 'bg-green-500' : 'bg-crate-elevated'
+                      }`}
+                    >
+                      <span
+                        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                          enabled ? 'translate-x-6' : 'translate-x-1'
+                        }`}
+                      />
+                    </button>
+                    <span className="text-sm text-crate-cream">
+                      Enable automatic daily sync
+                    </span>
+                  </div>
+
+                  <div className="pt-4">
+                    <button
+                      onClick={handleSave}
+                      disabled={saving}
+                      className="btn-primary"
+                    >
+                      {saving ? 'Saving...' : 'Save Configuration'}
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Sync History */}
+          {config?.configured && (
+            <div className="card overflow-hidden">
+              <div className="p-5 border-b border-crate-border flex items-center gap-2">
+                <History size={18} className="text-crate-muted" />
+                <h2 className="text-lg font-display font-semibold text-crate-cream">Sync History</h2>
+              </div>
+
+              {history.length === 0 ? (
+                <div className="text-center py-12">
+                  <History size={32} className="mx-auto text-crate-subtle mb-3" />
+                  <p className="text-crate-muted">No sync history yet</p>
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="border-b border-crate-border bg-crate-elevated/50">
+                        <th className="text-left py-3 px-5 text-xs uppercase tracking-wider text-crate-subtle font-medium">
+                          Date
+                        </th>
+                        <th className="text-right py-3 px-5 text-xs uppercase tracking-wider text-crate-subtle font-medium">
+                          Added
+                        </th>
+                        <th className="text-right py-3 px-5 text-xs uppercase tracking-wider text-crate-subtle font-medium">
+                          Skipped
+                        </th>
+                        <th className="text-left py-3 px-5 text-xs uppercase tracking-wider text-crate-subtle font-medium">
+                          Status
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-crate-border/50">
+                      {history.map((h, idx) => (
+                        <tr
+                          key={h.id}
+                          className="stagger-item hover:bg-crate-elevated/30 transition-colors"
+                          style={{ animationDelay: `${idx * 30}ms` }}
+                        >
+                          <td className="py-4 px-5 text-crate-cream">
+                            {formatDate(h.started_at)}
+                          </td>
+                          <td className="py-4 px-5 text-right text-green-500 tabular-nums">
+                            +{h.tracks_added}
+                          </td>
+                          <td className="py-4 px-5 text-right text-crate-muted tabular-nums">
+                            {h.tracks_skipped}
+                          </td>
+                          <td className="py-4 px-5">
+                            {h.error_message ? (
+                              <span className="text-red-500 text-sm" title={h.error_message}>
+                                Failed
+                              </span>
+                            ) : h.completed_at ? (
+                              <span className="text-green-500 text-sm">Success</span>
+                            ) : (
+                              <span className="text-crate-amber text-sm">Running</span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* How It Works */}
+          <div className="card p-5">
+            <h3 className="text-sm font-medium text-crate-cream mb-3">How It Works</h3>
+            <ul className="text-sm text-crate-muted space-y-2">
+              <li>1. Connect your Spotify account using the button above</li>
+              <li>2. Enable automatic sync to run daily</li>
+              <li>3. Liked songs will be searched and downloaded as MP3s</li>
+              <li>4. Tracks are added to a "Spotify Liked Songs" crate</li>
+              <li>5. Already-synced tracks are skipped automatically</li>
+            </ul>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Adds a new `backend/monochrome` client and wires Spotify sync to prefer FLAC via monochrome.tf (reverse-engineered TIDAL API) before falling back to the existing yt-dlp MP3 path. Ships alongside the previously-unmerged Spotify integration from `feature/spotify-integration`.

## What changed

**New: `backend/monochrome` client**
- Multi-backend failover (hosts tried in order; `{\"detail\":\"...\"}` upstream errors trigger failover so a single mirror's banned TIDAL account doesn't break everything)
- Browser-like User-Agent (Cloudflare on several mirrors 403s Go's default `Go-http-client/1.1`)
- Text search via `/search/?s=...` (the public API has **no ISRC query param** despite what community docs claim — ISRC matching has to be done client-side)
- `/track/` → base64 BTS manifest → signed CDN URL → `Download()`
- Rejects DASH manifests and non-`NONE` encryption (Atmos/MQA) so the caller can fall back cleanly
- 12 unit tests covering parsing, failover, aggregated errors, DRM rejection, empty-body guards

**Spotify integration (merged from `feature/spotify-integration` and extended)**
- Captures `external_ids.isrc` on each liked-song fetch
- `downloadAndImportTrack` tries monochrome first when the client is configured and the track has an ISRC:
  - Free-text search `\"artist title\"` on 50 results
  - Requires exact (case-insensitive) ISRC match
  - ±5s duration sanity check against wrong-version hits (clean vs explicit, edit vs album)
  - Requires `codec=flac` (guards against silent downgrades to AAC when the backend is restricted)
- Any failure falls through transparently to the existing yt-dlp MP3 path
- Spotify sync migration renumbered `003 → 004` to avoid collision with the existing `003_add_track_analysis.sql` from main

**Config**
- New env var: `MONOCHROME_API_URL` — comma-separated list of backends (empty = disabled)

## Why

User wanted Spotify liked songs to land as lossless FLAC instead of 320 MP3. Monochrome.tf proxies TIDAL, which has Hi-Res lossless catalog; ISRC matching gives high-confidence automated lookups.

## Reviewer notes

**Live-verified end-to-end.** With `MONOCHROME_API_URL=https://api.monochrome.tf,https://hund.qqdl.site,https://katze.qqdl.site`, the client correctly skips the broken first mirror (TIDAL-banned) and downloaded a 36 MB FLAC for Bohemian Rhapsody (ISRC `GBUM71029604`).

**Suggested backend list for now:** `https://hund.qqdl.site,https://katze.qqdl.site,https://api.monochrome.tf`. Put working ones first; keep broken ones in the list as future recovery fallbacks. Mirrors rotate as TIDAL bans/unbans them.

**Legal posture:** monochrome.tf reverse-engineers TIDAL's paid API. This integration is optional (disabled by default — requires setting the env var) and inherits whatever legal exposure the user has already accepted by running the existing yt-dlp YouTube-ripping path.

**Known gaps / follow-ups:**
- No liveness probe on startup — 120s timeout × N liked songs on a fully-dead backend list could stall a sync
- No circuit breaker after consecutive failures
- No frontend toggle for monochrome on/off (just env var)
- `tryMonochromeDownload` has no integration test (consistent with the rest of the spotify package which has zero tests)

## Test plan

- [x] `go build ./...` green
- [x] `go test ./...` green — 12 new tests in `backend/monochrome`
- [x] `go vet ./...` clean
- [x] Live: search returns correct ISRC match against real mirror
- [x] Live: 36 MB FLAC successfully downloaded end-to-end with multi-backend failover
- [ ] Reviewer: verify Spotify sync end-to-end with a real Spotify account + `MONOCHROME_API_URL` set; confirm tracks land in the library as `.flac` with correct metadata
- [ ] Reviewer: disable `MONOCHROME_API_URL`; confirm sync still falls back to yt-dlp MP3 as before

## Commits

- `0019979` — merge: feature/spotify-integration; renumber spotify migration to 004
- `f59e00e` — feat(spotify): try monochrome.tf for FLAC via ISRC before yt-dlp fallback
- `056cc0b` — fix(spotify): reject non-FLAC codecs from monochrome to avoid wrong extension
- `eeed41d` — fix(monochrome): real API uses s=, not i=; filter ISRC client-side
- `d435426` — feat(monochrome): multi-backend failover + browser UA