### PR TITLE
feat(library): infinite scroll for track list

### DIFF
--- a/frontend/src/hooks/useQueries.ts
+++ b/frontend/src/hooks/useQueries.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api, cratesApi, normalizeCrateList, tracksApi } from '../lib/api'
 import type { CrateList, TrackList } from '../types/crates'
 
@@ -12,6 +12,9 @@ export const queryKeys = {
 const emptyCrateList: CrateList = { crates: [], total: 0, limit: 20, offset: 0, has_next: false }
 const emptyTrackList: TrackList = { tracks: [], total: 0, limit: 20, offset: 0, has_next: false }
 
+// Backend caps per-request track lists at 100; we page through via offset.
+const TRACKS_PAGE_SIZE = 100
+
 // Crates query hook
 export function useCrates() {
   return useQuery({
@@ -24,33 +27,51 @@ export function useCrates() {
   })
 }
 
-// Tracks query hook
+// Tracks query hook — paginates via useInfiniteQuery, exposes a flattened
+// TrackList via `data` so consumers keep their existing shape.
 export function useTracks(params: { q?: string; selectedCrate?: string }) {
   const { q, selectedCrate } = params
 
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: queryKeys.tracks(params),
-    queryFn: async () => {
-      let data
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) => {
+      const offset = pageParam as number
+      const pageParams = { q: q || undefined, limit: TRACKS_PAGE_SIZE, offset }
+
+      let response
       if (selectedCrate === 'unsorted') {
-        const response = await tracksApi.getUnsorted({ q: q || undefined })
-        data = response.data
+        response = await tracksApi.getUnsorted(pageParams)
       } else if (selectedCrate && selectedCrate !== 'all') {
-        const response = await api.get('/api/tracks', {
-          params: { q: q || undefined, playlist_id: selectedCrate }
+        response = await api.get('/api/tracks', {
+          params: { ...pageParams, playlist_id: selectedCrate },
         })
-        data = response.data
       } else {
-        const response = await api.get('/api/tracks', { params: { q: q || undefined } })
-        data = response.data
+        response = await api.get('/api/tracks', { params: pageParams })
       }
 
-      if (data && data.tracks && Array.isArray(data.tracks)) {
+      const data = response.data
+      if (data && Array.isArray(data.tracks)) {
         return data as TrackList
       }
       return emptyTrackList
     },
-    placeholderData: emptyTrackList,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.has_next) return undefined
+      return lastPage.offset + lastPage.tracks.length
+    },
+    select: (data) => {
+      const pages = data.pages as TrackList[]
+      const tracks = pages.flatMap((p) => p.tracks)
+      const last = pages[pages.length - 1]
+      return {
+        tracks,
+        total: last?.total ?? tracks.length,
+        limit: last?.limit ?? TRACKS_PAGE_SIZE,
+        offset: 0,
+        has_next: Boolean(last?.has_next),
+      } as TrackList
+    },
   })
 }
 

--- a/frontend/src/pages/LibraryPage.tsx
+++ b/frontend/src/pages/LibraryPage.tsx
@@ -139,10 +139,31 @@ export function LibraryPage() {
   }, [searchInput])
 
   const { data: crates, isLoading: loadingCrates } = useCrates()
-  const { data: tracks, isLoading: loadingTracks } = useTracks({
+  const {
+    data: tracks,
+    isLoading: loadingTracks,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useTracks({
     q: debouncedSearch || undefined,
     selectedCrate,
   })
+
+  const [sentinelEl, setSentinelEl] = useState<HTMLDivElement | null>(null)
+  useEffect(() => {
+    if (!sentinelEl) return
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage()
+        }
+      },
+      { rootMargin: '200px' },
+    )
+    io.observe(sentinelEl)
+    return () => io.disconnect()
+  }, [sentinelEl, hasNextPage, isFetchingNextPage, fetchNextPage])
 
   const deleteTrackMutation = useDeleteTrack()
   const addTracksMutation = useAddTracksToCrate()
@@ -364,7 +385,9 @@ export function LibraryPage() {
         </div>
         {tracks?.tracks && tracks.tracks.length > 0 && (
           <div className="text-sm text-crate-subtle">
-            {tracks.tracks.length} track{tracks.tracks.length !== 1 ? 's' : ''}
+            {tracks.total > tracks.tracks.length
+              ? `${tracks.tracks.length} of ${tracks.total} tracks`
+              : `${tracks.total} track${tracks.total !== 1 ? 's' : ''}`}
           </div>
         )}
       </div>
@@ -685,6 +708,16 @@ export function LibraryPage() {
             </div>
           )
         })}
+
+        {/* Infinite-scroll sentinel + status row */}
+        {!loadingTracks && tracks?.tracks && tracks.tracks.length > 0 && hasNextPage && (
+          <div
+            ref={setSentinelEl}
+            className="px-4 py-6 text-center text-sm text-crate-subtle"
+          >
+            {isFetchingNextPage ? 'Loading more…' : 'Scroll for more'}
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Library/playlist views previously capped at 20 tracks because `useTracks` was a plain `useQuery` that never requested `limit`/`offset`, so the backend's default of 20 applied.
- Converts `useTracks` to `useInfiniteQuery`, paging in chunks of 100 (the backend's hard cap) via `offset`, and flattens pages into a `TrackList` through `select` so existing consumers don't change.
- Adds an `IntersectionObserver` sentinel at the bottom of the track list in `LibraryPage` that calls `fetchNextPage` when scrolled into view, with a "Loading more…" row for feedback.
- Track-count label now reads `X of Y tracks` while pages are still unloaded, and falls back to `Y tracks` once everything is in.

## Why
Playlists/crates with more than 20 tracks silently truncated in the UI. Root cause was purely client-side — the backend already returns `has_next`, `total`, and accepts `limit`/`offset`, but the frontend wasn't consuming them. No backend changes needed.

## Test plan
- [ ] Library view (`/library`) with >100 tracks: scroll past the bottom, next page loads, keeps loading until `has_next` is false.
- [ ] Select a crate with >20 tracks from the sidebar — all tracks eventually load via scroll.
- [ ] "Unsorted" crate view pages the same way.
- [ ] Search input debounces and starts a fresh paged query at offset 0.
- [ ] Bulk select-all toggles all currently loaded tracks; adding/removing to a crate invalidates and refetches cleanly.
- [ ] Double-click edit of BPM / Key still works and the mutation refreshes the list.
- [ ] Select all + Download kicks off downloads only for loaded tracks (existing behavior).

https://claude.ai/code/session_01QJ1aHCAyAGyoLeV6FsYmxw

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJ1aHCAyAGyoLeV6FsYmxw)_