### PR TITLE
feat(cover-art): capture and serve cover art for tracks

### DIFF
--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -162,5 +162,22 @@ func (d *DB) migrate() error {
 		}
 	}
 
+	// Check if cover_path column exists on tracks table
+	var coverColCount int
+	_ = d.QueryRow(`
+		SELECT COUNT(*)
+		FROM pragma_table_info('tracks')
+		WHERE name='cover_path'
+	`).Scan(&coverColCount)
+	if coverColCount == 0 {
+		migrationSQL, err := migrationsFS.ReadFile("migrations/006_add_track_cover.sql")
+		if err != nil {
+			return fmt.Errorf("failed to read migration 006_add_track_cover: %w", err)
+		}
+		if _, err := d.Exec(string(migrationSQL)); err != nil {
+			return fmt.Errorf("failed to execute migration 006_add_track_cover: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/backend/internal/db/migrations/006_add_track_cover.sql
+++ b/backend/internal/db/migrations/006_add_track_cover.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tracks ADD COLUMN cover_path TEXT;

--- a/backend/internal/db/migrations/schema.sql
+++ b/backend/internal/db/migrations/schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS tracks (
     analysis_retry_count INTEGER NOT NULL DEFAULT 0,
     next_retry_at DATETIME,
     file_path TEXT NOT NULL,
+    cover_path TEXT,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -33,6 +33,7 @@ type Track struct {
 	AnalyzedAt       *time.Time `json:"analyzed_at,omitempty"`
 	AnalysisStatus   string     `json:"analysis_status"`
 	FilePath         string     `json:"file_path"`
+	CoverPath        *string    `json:"cover_path,omitempty"`
 	CreatedAt        time.Time  `json:"created_at"`
 	UpdatedAt        time.Time  `json:"updated_at"`
 }

--- a/backend/soundcloud/downloader.py
+++ b/backend/soundcloud/downloader.py
@@ -73,12 +73,18 @@ def get_soundcloud_likes(oauth_token: str, page_size: int = 200, max_pages: int 
         for item in likes_data.get('collection', []):
             track = item.get('track')
             if track:
+                # SoundCloud returns artwork at e.g. "-large.jpg" (~100x100); upgrade to
+                # "-t500x500" (500x500) when present so we get a usable thumbnail.
+                artwork_url = track.get('artwork_url')
+                if artwork_url and '-large.' in artwork_url:
+                    artwork_url = artwork_url.replace('-large.', '-t500x500.')
                 tracks.append({
                     'id': track.get('id'),
                     'title': track.get('title', 'Unknown'),
                     'artist': track.get('user', {}).get('username', 'Unknown'),
                     'duration': track.get('duration', 0) // 1000,  # ms to seconds
                     'permalink_url': track.get('permalink_url'),
+                    'artwork_url': artwork_url,
                 })
 
         next_href = likes_data.get('next_href')
@@ -93,6 +99,35 @@ def get_soundcloud_likes(oauth_token: str, page_size: int = 200, max_pages: int 
 
     print(f"Found {len(tracks)} liked tracks")
     return tracks
+
+
+def _download_cover(artwork_url, output_dir: str, track_id) -> str:
+    """Download cover art for a track. Returns absolute file path on success, '' on failure."""
+    if not artwork_url:
+        return ''
+    try:
+        ext = '.jpg'
+        lower = artwork_url.lower().split('?', 1)[0]
+        if lower.endswith('.png'):
+            ext = '.png'
+        elif lower.endswith('.webp'):
+            ext = '.webp'
+        elif lower.endswith('.jpeg') or lower.endswith('.jpg'):
+            ext = '.jpg'
+
+        cover_path = os.path.join(output_dir, f'{track_id}_cover{ext}')
+        req = urllib.request.Request(artwork_url)
+        req.add_header('User-Agent', 'Mozilla/5.0')
+        with urllib.request.urlopen(req, timeout=15, context=ssl_context) as response:
+            data = response.read()
+        if not data:
+            return ''
+        with open(cover_path, 'wb') as f:
+            f.write(data)
+        return cover_path
+    except Exception as e:
+        print(f"  ! Cover download failed for {track_id}: {e}", file=sys.stderr)
+        return ''
 
 
 def download_tracks(tracks: list, output_dir: str, max_tracks: int = 50) -> list:
@@ -140,14 +175,18 @@ def download_tracks(tracks: list, output_dir: str, max_tracks: int = 50) -> list
             # Check if file was downloaded
             expected_file = os.path.join(output_dir, f'{track_id}.mp3')
             if os.path.exists(expected_file):
-                manifest.append({
+                cover_path = _download_cover(track.get('artwork_url'), output_dir, track_id)
+                entry = {
                     'file_path': expected_file,
                     'title': title,
                     'artist': artist,
                     'duration': track.get('duration', 0),
                     'soundcloud_id': str(track_id)
-                })
-                print(f"  ✓ Downloaded successfully")
+                }
+                if cover_path:
+                    entry['cover_path'] = cover_path
+                manifest.append(entry)
+                print(f"  ✓ Downloaded successfully" + (" (with cover)" if cover_path else ""))
             else:
                 print(f"  ✗ File not found after download")
 

--- a/backend/soundcloud/manager.go
+++ b/backend/soundcloud/manager.go
@@ -53,6 +53,7 @@ type ManifestEntry struct {
 	Artist       string `json:"artist"`
 	Duration     int    `json:"duration"`
 	SoundCloudID string `json:"soundcloud_id"`
+	CoverPath    string `json:"cover_path,omitempty"`
 }
 
 func (m *Manager) GetSyncConfig(ctx context.Context) (*SyncConfig, error) {
@@ -301,7 +302,33 @@ func (m *Manager) importTrack(ctx context.Context, userID string, entry Manifest
 		return "", fmt.Errorf("failed to create track record: %w", err)
 	}
 
+	if entry.CoverPath != "" {
+		if err := m.attachCover(ctx, track, entry.CoverPath); err != nil {
+			fmt.Printf("[SoundCloud] Warning: failed to attach cover for %s: %v\n", entry.Title, err)
+		}
+	}
+
 	return track.ID, nil
+}
+
+// attachCover copies a downloaded cover sidecar into the track's storage directory
+// and updates the track's cover_path. Best-effort — errors are returned but logged
+// by the caller; track import is not aborted on cover failure.
+func (m *Manager) attachCover(ctx context.Context, track *imodels.Track, srcPath string) error {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return fmt.Errorf("open cover: %w", err)
+	}
+	defer src.Close()
+
+	coverRel, err := tracks.SaveCoverSidecar(ctx, m.storage, track.FilePath, "", srcPath, src)
+	if err != nil {
+		return err
+	}
+	if err := m.tracksRepo.UpdateCoverPath(ctx, track.ID, coverRel); err != nil {
+		return fmt.Errorf("update cover path: %w", err)
+	}
+	return nil
 }
 
 func (m *Manager) TestDownload(ctx context.Context, url string) (string, error) {

--- a/backend/spotify/manager.go
+++ b/backend/spotify/manager.go
@@ -248,6 +248,14 @@ func (m *Manager) getValidToken(ctx context.Context) (string, error) {
 	return *cfg.AccessToken, nil
 }
 
+// SpotifyImage represents an image returned by the Spotify API.
+// Spotify orders Images largest-first; height/width may be null in some responses.
+type SpotifyImage struct {
+	URL    string `json:"url"`
+	Height int    `json:"height"`
+	Width  int    `json:"width"`
+}
+
 // SpotifyTrack represents a track from Spotify API
 type SpotifyTrack struct {
 	ID      string `json:"id"`
@@ -256,7 +264,8 @@ type SpotifyTrack struct {
 		Name string `json:"name"`
 	} `json:"artists"`
 	Album struct {
-		Name string `json:"name"`
+		Name   string         `json:"name"`
+		Images []SpotifyImage `json:"images"`
 	} `json:"album"`
 	DurationMs   int `json:"duration_ms"`
 	ExternalURLs struct {
@@ -652,7 +661,47 @@ func (m *Manager) downloadAndImportTrack(ctx context.Context, userID string, st 
 		return "", fmt.Errorf("failed to create track record: %w", err)
 	}
 
+	if err := m.attachCover(ctx, track, st); err != nil {
+		fmt.Printf("[Spotify] Warning: failed to attach cover for %s: %v\n", st.Name, err)
+	}
+
 	return track.ID, nil
+}
+
+// attachCover downloads the largest album image returned by Spotify and writes it
+// as a sidecar next to the track. Best-effort — failures are logged by the caller.
+func (m *Manager) attachCover(ctx context.Context, track *imodels.Track, st SpotifyTrack) error {
+	if len(st.Album.Images) == 0 {
+		return nil
+	}
+	imgURL := st.Album.Images[0].URL
+	if imgURL == "" {
+		return nil
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, "GET", imgURL, nil)
+	if err != nil {
+		return fmt.Errorf("build cover request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch cover: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("cover fetch returned %d", resp.StatusCode)
+	}
+
+	coverRel, err := tracks.SaveCoverSidecar(ctx, m.storage, track.FilePath, resp.Header.Get("Content-Type"), imgURL, resp.Body)
+	if err != nil {
+		return err
+	}
+	if err := m.tracksRepo.UpdateCoverPath(ctx, track.ID, coverRel); err != nil {
+		return fmt.Errorf("update cover path: %w", err)
+	}
+	return nil
 }
 
 func getArtistName(st SpotifyTrack) string {

--- a/backend/tracks/routes.go
+++ b/backend/tracks/routes.go
@@ -13,6 +13,7 @@ func Routes(m *Manager, pm *playlists.Manager) func(*gin.RouterGroup) {
 		g.POST("", UploadHandler(m, pm))
 		g.GET("", ListHandler(m, pm))
 		g.GET("/:id/stream", StreamHandler(m))
+		g.GET("/:id/cover", CoverHandler(m))
 		g.GET("/:id/download", DownloadHandler(m))
 		g.DELETE("/:id", DeleteHandler(m))
 		g.GET("/:id", GetHandler(m))

--- a/backend/tracks/tracksdata.go
+++ b/backend/tracks/tracksdata.go
@@ -25,7 +25,7 @@ func NewRepository(db *db.DB) *Repository {
 func scanTrack(row interface{ Scan(dest ...any) error }) (*imodels.Track, error) {
 	var t imodels.Track
 	var duration, bpm, bpmConf, keyConf sql.NullFloat64
-	var title, artist, album, genre, key sql.NullString
+	var title, artist, album, genre, key, coverPath sql.NullString
 	var year, sampleRate, bitrate sql.NullInt64
 	var analyzedAt sql.NullTime
 
@@ -33,7 +33,7 @@ func scanTrack(row interface{ Scan(dest ...any) error }) (*imodels.Track, error)
 		&t.ID, &t.OwnerUserID, &t.OriginalFilename, &t.ContentType, &t.SizeBytes,
 		&duration, &title, &artist, &album, &genre, &year, &sampleRate, &bitrate,
 		&bpm, &bpmConf, &key, &keyConf, &analyzedAt, &t.AnalysisStatus,
-		&t.FilePath, &t.CreatedAt, &t.UpdatedAt,
+		&t.FilePath, &coverPath, &t.CreatedAt, &t.UpdatedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -85,6 +85,10 @@ func scanTrack(row interface{ Scan(dest ...any) error }) (*imodels.Track, error)
 	if analyzedAt.Valid {
 		t.AnalyzedAt = &analyzedAt.Time
 	}
+	if coverPath.Valid {
+		v := coverPath.String
+		t.CoverPath = &v
+	}
 	return &t, nil
 }
 
@@ -94,11 +98,11 @@ func (r *Repository) CreateTrack(ctx context.Context, track *imodels.Track) (*im
 
 	_, err := r.db.ExecContext(ctx,
 		`INSERT INTO tracks (id, owner_user_id, original_filename, content_type, size_bytes,
-			duration_seconds, title, artist, album, genre, year, sample_rate, bitrate, file_path, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			duration_seconds, title, artist, album, genre, year, sample_rate, bitrate, file_path, cover_path, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, track.OwnerUserID, track.OriginalFilename, track.ContentType, track.SizeBytes,
 		track.DurationSeconds, track.Title, track.Artist, track.Album, track.Genre, track.Year,
-		track.SampleRate, track.Bitrate, track.FilePath, track.CreatedAt, track.UpdatedAt,
+		track.SampleRate, track.Bitrate, track.FilePath, track.CoverPath, track.CreatedAt, track.UpdatedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -113,7 +117,7 @@ func (r *Repository) GetTracks(ctx context.Context, userID string, limit, offset
 	query := `SELECT id, owner_user_id, original_filename, content_type, size_bytes,
 		duration_seconds, title, artist, album, genre, year, sample_rate, bitrate,
 		bpm, bpm_confidence, musical_key, key_confidence, analyzed_at, analysis_status,
-		file_path, created_at, updated_at
+		file_path, cover_path, created_at, updated_at
 		FROM tracks WHERE owner_user_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?`
 
 	rows, err := r.db.QueryContext(ctx, query, userID, limit, offset)
@@ -146,7 +150,7 @@ func (r *Repository) GetAllTracks(ctx context.Context, limit, offset int, search
 				t.duration_seconds, t.title, t.artist, t.album, t.genre, t.year,
 				t.sample_rate, t.bitrate,
 				t.bpm, t.bpm_confidence, t.musical_key, t.key_confidence, t.analyzed_at, t.analysis_status,
-				t.file_path, t.created_at, t.updated_at
+				t.file_path, t.cover_path, t.created_at, t.updated_at
 			FROM tracks t
 			INNER JOIN tracks_fts fts ON t.id = fts.track_id
 			WHERE tracks_fts MATCH ?
@@ -161,7 +165,7 @@ func (r *Repository) GetAllTracks(ctx context.Context, limit, offset int, search
 			SELECT id, owner_user_id, original_filename, content_type, size_bytes,
 				duration_seconds, title, artist, album, genre, year, sample_rate, bitrate,
 				bpm, bpm_confidence, musical_key, key_confidence, analyzed_at, analysis_status,
-				file_path, created_at, updated_at
+				file_path, cover_path, created_at, updated_at
 			FROM tracks
 			ORDER BY created_at DESC
 			LIMIT ? OFFSET ?
@@ -193,7 +197,7 @@ func (r *Repository) GetTrackByID(ctx context.Context, trackID string) (*imodels
 		`SELECT id, owner_user_id, original_filename, content_type, size_bytes,
 		duration_seconds, title, artist, album, genre, year, sample_rate, bitrate,
 		bpm, bpm_confidence, musical_key, key_confidence, analyzed_at, analysis_status,
-		file_path, created_at, updated_at
+		file_path, cover_path, created_at, updated_at
 		FROM tracks WHERE id = ?`,
 		trackID,
 	)
@@ -230,7 +234,7 @@ func (r *Repository) SearchTracks(ctx context.Context, query string, userID stri
 			t.duration_seconds, t.title, t.artist, t.album, t.genre, t.year,
 			t.sample_rate, t.bitrate,
 			t.bpm, t.bpm_confidence, t.musical_key, t.key_confidence, t.analyzed_at, t.analysis_status,
-			t.file_path, t.created_at, t.updated_at
+			t.file_path, t.cover_path, t.created_at, t.updated_at
 		FROM tracks t
 		INNER JOIN tracks_fts fts ON t.id = fts.track_id
 		WHERE t.owner_user_id = ?
@@ -311,6 +315,15 @@ func prepareFTS5Query(query string) string {
 	// "feel the vibration" becomes "feel* AND the* AND vibration*"
 	// "on & on" becomes "on* AND on*" (& is removed, both "on" terms must match)
 	return strings.Join(terms, " AND ")
+}
+
+// UpdateCoverPath sets the cover_path for a track.
+func (r *Repository) UpdateCoverPath(ctx context.Context, trackID, coverPath string) error {
+	_, err := r.db.ExecContext(ctx,
+		"UPDATE tracks SET cover_path = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+		coverPath, trackID,
+	)
+	return err
 }
 
 // UpdateAnalysisOverride sets user-edited BPM and/or key and flips status to 'user_edited'.

--- a/backend/tracks/trackshandler.go
+++ b/backend/tracks/trackshandler.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -258,6 +260,49 @@ func StreamHandler(manager *Manager) gin.HandlerFunc {
 
 		io.CopyN(c.Writer, file, chunkSize)
 		fmt.Printf("[StreamProfiler] Total request time: %v\n", time.Since(startTime))
+	}
+}
+
+// CoverHandler serves the cover-art sidecar image for a track.
+// Mirrors the auth pattern in StreamHandler. Returns 404 when the track has no cover.
+func CoverHandler(manager *Manager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		trackID := c.Param("id")
+		userID, _ := c.Get("user_id")
+		userRole, _ := c.Get("user_role")
+
+		track, err := manager.GetStreamInfo(c.Request.Context(), trackID)
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "track_not_found", "message": "Track not found"}})
+			return
+		}
+
+		if userRole != "admin" && track.OwnerUserID != userID.(string) {
+			c.JSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "access_denied", "message": "Access denied"}})
+			return
+		}
+
+		if track.CoverPath == nil || *track.CoverPath == "" {
+			c.JSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "cover_not_found", "message": "No cover art for this track"}})
+			return
+		}
+
+		file, info, err := manager.OpenFile(c.Request.Context(), *track.CoverPath)
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": gin.H{"code": "cover_not_found", "message": "Cover file missing"}})
+			return
+		}
+		defer file.Close()
+
+		ctype := mime.TypeByExtension(filepath.Ext(*track.CoverPath))
+		if ctype == "" {
+			ctype = "image/jpeg"
+		}
+		c.Header("Content-Type", ctype)
+		c.Header("Content-Length", strconv.FormatInt(info.Size, 10))
+		c.Header("Cache-Control", "private, max-age=86400, immutable")
+		c.Status(http.StatusOK)
+		io.Copy(c.Writer, file)
 	}
 }
 

--- a/backend/tracks/tracksmanager.go
+++ b/backend/tracks/tracksmanager.go
@@ -7,6 +7,8 @@ import (
 	"mime/multipart"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/faraz525/home-music-server/backend/internal/media/metadata"
 	imodels "github.com/faraz525/home-music-server/backend/internal/models"
@@ -67,6 +69,17 @@ func (m *Manager) UploadTrack(ctx context.Context, userID string, fileHeader *mu
 		md = &metadata.AudioMetadata{}
 	}
 
+	// Pull embedded album art out into a sidecar BEFORE the sanitizer strips it
+	// from the audio file. This preserves the art for display while keeping the
+	// audio file small for fast streaming start-up.
+	coverTmp, coverErr := extractEmbeddedCover(ctx, fullPath)
+	if coverErr != nil {
+		fmt.Printf("[CrateDrop] No embedded cover for %s (or extract failed): %v\n", trackID, coverErr)
+	}
+	if coverTmp != "" {
+		defer os.Remove(coverTmp)
+	}
+
 	// Sanitize over-sized metadata blobs (e.g. embedded album art) that delay playback
 	if updatedSize, err := m.sanitizeIfNeeded(ctx, contentType, fullPath); err != nil {
 		fmt.Printf("[CrateDrop] Warning: failed to sanitize track %s: %v\n", trackID, err)
@@ -113,7 +126,63 @@ func (m *Manager) UploadTrack(ctx context.Context, userID string, fileHeader *mu
 	}
 	fmt.Printf("[CrateDrop] Track successfully saved with ID: %s\n", track.ID)
 
+	// Attach the cover we extracted before sanitize, if any.
+	if coverTmp != "" {
+		if err := m.attachExtractedCover(ctx, track, coverTmp); err != nil {
+			fmt.Printf("[CrateDrop] Warning: failed to attach extracted cover for %s: %v\n", track.ID, err)
+		}
+	}
+
 	return track, nil
+}
+
+// attachExtractedCover moves a tmp cover file into the track's storage directory
+// and updates cover_path. Best-effort.
+func (m *Manager) attachExtractedCover(ctx context.Context, track *imodels.Track, tmpPath string) error {
+	src, err := os.Open(tmpPath)
+	if err != nil {
+		return fmt.Errorf("open tmp cover: %w", err)
+	}
+	defer src.Close()
+	coverRel, err := SaveCoverSidecar(ctx, m.storage, track.FilePath, "image/jpeg", tmpPath, src)
+	if err != nil {
+		return err
+	}
+	if err := m.repo.UpdateCoverPath(ctx, track.ID, coverRel); err != nil {
+		return fmt.Errorf("update cover path: %w", err)
+	}
+	return nil
+}
+
+// extractEmbeddedCover runs ffmpeg to pull the attached picture out of an audio file
+// into a JPEG tmp file. Returns the tmp path on success, or an error when no picture
+// is embedded / ffmpeg fails. The caller owns the returned tmp file.
+func extractEmbeddedCover(ctx context.Context, audioPath string) (string, error) {
+	tmpFile, err := os.CreateTemp("", "cratedrop-cover-*.jpg")
+	if err != nil {
+		return "", fmt.Errorf("create cover tmp: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	// ffmpeg won't overwrite a file unless we pass -y; we just truncated it above
+	// so it's empty. -an drops audio, default mapping selects the embedded picture.
+	cmd := exec.CommandContext(ctx, "ffmpeg",
+		"-y",
+		"-i", audioPath,
+		"-an",
+		"-frames:v", "1",
+		tmpPath,
+	)
+	output, runErr := cmd.CombinedOutput()
+	info, statErr := os.Stat(tmpPath)
+	if runErr != nil || statErr != nil || info == nil || info.Size() == 0 {
+		os.Remove(tmpPath)
+		if runErr != nil {
+			return "", fmt.Errorf("ffmpeg cover extract: %w (output: %s)", runErr, strings.TrimSpace(string(output)))
+		}
+		return "", fmt.Errorf("ffmpeg produced no cover")
+	}
+	return tmpPath, nil
 }
 
 // sanitizeIfNeeded strips excessive metadata (like multi-megabyte album art) from MP3s.
@@ -253,6 +322,69 @@ func parseID3Size(b []byte) int {
 	return size
 }
 
+// SaveCoverSidecar writes an image as a sibling `cover.<ext>` file next to the track
+// and returns the relative cover path (relative to dataDir, mirroring track.FilePath).
+// Use sourcePath to indicate the source filename or url so a sensible extension is chosen
+// when contentType is empty or generic.
+func SaveCoverSidecar(ctx context.Context, store storage.Storage, trackFilePath, contentType, sourcePath string, r io.Reader) (string, error) {
+	ext := coverExt(contentType, sourcePath)
+	parentRel := filepath.Dir(trackFilePath)
+	coverRel := filepath.Join(parentRel, "cover"+ext)
+
+	fullPath, ok := store.ResolveFullPath(coverRel)
+	if !ok {
+		return "", fmt.Errorf("failed to resolve cover path")
+	}
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		return "", fmt.Errorf("failed to create cover dir: %w", err)
+	}
+
+	tmp := fullPath + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return "", fmt.Errorf("failed to create cover tmp: %w", err)
+	}
+	if _, err := io.Copy(f, r); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return "", fmt.Errorf("failed to write cover: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return "", fmt.Errorf("failed to close cover: %w", err)
+	}
+	if err := os.Rename(tmp, fullPath); err != nil {
+		os.Remove(tmp)
+		return "", fmt.Errorf("failed to rename cover: %w", err)
+	}
+	return coverRel, nil
+}
+
+// coverExt picks a file extension for the cover sidecar based on the image content
+// type or, as a fallback, the source filename/URL extension.
+func coverExt(contentType, sourcePath string) string {
+	switch strings.ToLower(strings.TrimSpace(contentType)) {
+	case "image/jpeg", "image/jpg":
+		return ".jpg"
+	case "image/png":
+		return ".png"
+	case "image/webp":
+		return ".webp"
+	}
+	if sourcePath != "" {
+		ext := strings.ToLower(filepath.Ext(sourcePath))
+		switch ext {
+		case ".jpg", ".jpeg":
+			return ".jpg"
+		case ".png":
+			return ".png"
+		case ".webp":
+			return ".webp"
+		}
+	}
+	return ".jpg"
+}
+
 // OpenFile exposes storage Open for streaming
 func (m *Manager) OpenFile(ctx context.Context, relativePath string) (storage.ReadSeekCloser, storage.FileInfo, error) {
 	return m.storage.Open(ctx, relativePath)
@@ -313,6 +445,13 @@ func (m *Manager) DeleteTrack(ctx context.Context, trackID string) error {
 	// Delete file via storage
 	if err := m.storage.Delete(ctx, track.FilePath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to delete file: %w", err)
+	}
+
+	// Delete cover sidecar if present (best-effort)
+	if track.CoverPath != nil && *track.CoverPath != "" {
+		if err := m.storage.Delete(ctx, *track.CoverPath); err != nil && !os.IsNotExist(err) {
+			fmt.Printf("[CrateDrop] Warning: failed to delete cover for track %s: %v\n", trackID, err)
+		}
 	}
 
 	// Delete from database

--- a/frontend/src/components/TrackCover.tsx
+++ b/frontend/src/components/TrackCover.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+
+type TrackCoverProps = {
+  trackId: string
+  hasCover: boolean
+  size?: number
+  className?: string
+  fallback: React.ReactNode
+  alt?: string
+}
+
+export function TrackCover({ trackId, hasCover, size = 40, className = '', fallback, alt }: TrackCoverProps) {
+  const [errored, setErrored] = useState(false)
+
+  if (!hasCover || errored) {
+    return <>{fallback}</>
+  }
+
+  return (
+    <img
+      src={`/api/tracks/${trackId}/cover`}
+      alt={alt || 'Cover art'}
+      loading="lazy"
+      width={size}
+      height={size}
+      className={`flex-shrink-0 rounded-md object-cover ${className}`}
+      style={{ width: size, height: size }}
+      onError={() => setErrored(true)}
+    />
+  )
+}

--- a/frontend/src/components/player/PlayerBar.tsx
+++ b/frontend/src/components/player/PlayerBar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Pause, Play, SkipBack, SkipForward } from 'lucide-react'
 import { usePlayer } from '../../state/player'
+import { TrackCover } from '../TrackCover'
 
 function VinylRecord({ isPlaying, size = 48 }: { isPlaying: boolean; size?: number }) {
   return (
@@ -278,7 +279,17 @@ export function PlayerBar() {
         <div className="sm:hidden space-y-3">
           {/* Track info with vinyl */}
           <div className="flex items-center gap-3">
-            <VinylRecord isPlaying={isPlaying} size={40} />
+            {current ? (
+              <TrackCover
+                trackId={current.id}
+                hasCover={!!current.coverPath}
+                size={40}
+                fallback={<VinylRecord isPlaying={isPlaying} size={40} />}
+                alt={current.title}
+              />
+            ) : (
+              <VinylRecord isPlaying={isPlaying} size={40} />
+            )}
             <div className="flex-1 min-w-0">
               <div className="truncate text-sm font-medium text-crate-cream">
                 {current?.title || 'No track selected'}
@@ -364,7 +375,17 @@ export function PlayerBar() {
 
           {/* Center: Vinyl + Track info + Progress */}
           <div className="flex items-center gap-4 flex-1 min-w-0">
-            <VinylRecord isPlaying={isPlaying} size={48} />
+            {current ? (
+              <TrackCover
+                trackId={current.id}
+                hasCover={!!current.coverPath}
+                size={48}
+                fallback={<VinylRecord isPlaying={isPlaying} size={48} />}
+                alt={current.title}
+              />
+            ) : (
+              <VinylRecord isPlaying={isPlaying} size={48} />
+            )}
 
             <div className="min-w-0 w-48">
               <div className="truncate text-sm font-medium text-crate-cream">

--- a/frontend/src/pages/CommunityPage.tsx
+++ b/frontend/src/pages/CommunityPage.tsx
@@ -72,7 +72,8 @@ export function CommunityPage() {
                 title: track.title || track.original_filename,
                 artist: track.artist || 'Unknown Artist',
                 streamUrl: `/api/tracks/${track.id}/stream`,
-                durationSeconds: track.duration_seconds
+                durationSeconds: track.duration_seconds,
+                coverPath: track.cover_path
             }, true)
         }
     }

--- a/frontend/src/pages/LibraryPage.tsx
+++ b/frontend/src/pages/LibraryPage.tsx
@@ -6,6 +6,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { MoreHorizontal, ListPlus, Play, Pause, Music, Download, Disc, Search, X } from 'lucide-react'
 import { useToast } from '../hooks/useToast'
 import { useCrates, useTracks, useDeleteTrack, useAddTracksToCrate, useRemoveTracksFromCrate, useUpdateTrackAnalysis } from '../hooks/useQueries'
+import { TrackCover } from '../components/TrackCover'
 
 function MiniVinyl({ spinning = false }: { spinning?: boolean }) {
   return (
@@ -530,12 +531,21 @@ export function LibraryPage() {
                       })()
                       const displayTitle = t.title || fallbackFromFilename || 'Unknown track'
                       const displayArtist = t.artist || 'Unknown artist'
-                      play({ id: t.id, title: displayTitle, artist: displayArtist, streamUrl: `/api/tracks/${t.id}/stream`, durationSeconds: t.duration_seconds }, true)
+                      play({ id: t.id, title: displayTitle, artist: displayArtist, streamUrl: `/api/tracks/${t.id}/stream`, durationSeconds: t.duration_seconds, coverPath: t.cover_path }, true)
                     }
                   }}
                 >
                   {isCurrentAndPlaying ? <Pause size={14} /> : <Play size={14} className="ml-0.5" />}
                 </button>
+                {t.cover_path && (
+                  <TrackCover
+                    trackId={t.id}
+                    hasCover={true}
+                    size={28}
+                    fallback={null}
+                    alt={t.title}
+                  />
+                )}
                 <div className="min-w-0">
                   <div className="flex items-center gap-2">
                     {isCurrent && <MiniVinyl spinning={isPlaying} />}
@@ -574,12 +584,21 @@ export function LibraryPage() {
                       })()
                       const displayTitle = t.title || fallbackFromFilename || 'Unknown track'
                       const displayArtist = t.artist || 'Unknown artist'
-                      play({ id: t.id, title: displayTitle, artist: displayArtist, streamUrl: `/api/tracks/${t.id}/stream`, durationSeconds: t.duration_seconds }, true)
+                      play({ id: t.id, title: displayTitle, artist: displayArtist, streamUrl: `/api/tracks/${t.id}/stream`, durationSeconds: t.duration_seconds, coverPath: t.cover_path }, true)
                     }
                   }}
                 >
                   {isCurrentAndPlaying ? <Pause size={14} /> : <Play size={14} className="ml-0.5" />}
                 </button>
+                {t.cover_path && (
+                  <TrackCover
+                    trackId={t.id}
+                    hasCover={true}
+                    size={32}
+                    fallback={null}
+                    alt={t.title}
+                  />
+                )}
                 <div className="min-w-0">
                   <div className="flex items-center gap-2">
                     {isCurrent && <MiniVinyl spinning={isPlaying} />}

--- a/frontend/src/state/player.tsx
+++ b/frontend/src/state/player.tsx
@@ -7,6 +7,7 @@ export type QueueItem = {
   artist?: string
   streamUrl: string
   durationSeconds?: number // Duration from database for immediate playback
+  coverPath?: string
 }
 
 type PlayerContextValue = {
@@ -46,7 +47,8 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         title: track.title || track.original_filename,
         artist: track.artist || 'Unknown Artist',
         streamUrl: `/api/tracks/${track.id}/stream`,
-        durationSeconds: track.duration_seconds
+        durationSeconds: track.duration_seconds,
+        coverPath: track.cover_path
       }))
     } catch (error) {
       console.error('Failed to fetch playlist tracks:', error)

--- a/frontend/src/types/crates.ts
+++ b/frontend/src/types/crates.ts
@@ -73,6 +73,7 @@ export type Track = {
   analyzed_at?: string
   analysis_status?: 'pending' | 'analyzed' | 'failed' | 'user_edited'
   file_path?: string
+  cover_path?: string
   created_at?: string
   updated_at?: string
 }


### PR DESCRIPTION
## Summary

- Adds `cover_path` to `tracks` (migration 006) plus a sidecar file model — `library/user_<u>/track_<t>/cover.<ext>` next to the audio — and a new `GET /api/tracks/:id/cover` endpoint mirroring the stream handler's auth.
- Captures cover art at every ingestion point: SoundCloud sync (Python now keeps `artwork_url`, upgrades to `-t500x500`, downloads sidecar, surfaces `cover_path` in `manifest.json`), Spotify sync (deserializes `album.images`, fetches the largest with a 15s timeout), and direct uploads (ffmpeg extracts embedded ID3 art **before** the existing sanitize step so playback latency is unchanged).
- Frontend `<TrackCover>` component with vinyl-SVG fallback, used in `PlayerBar` (mobile + desktop) and as a small thumbnail in `LibraryPage` rows when present.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` clean
- [x] `npm run build` and `tsc --noEmit` clean
- [ ] Trigger a SoundCloud sync on the Pi → covers appear for newly synced tracks
- [ ] Trigger a Spotify sync → covers appear for newly synced tracks
- [ ] Upload a fresh MP3 with embedded art → cover renders, audio file size still small (sanitizer ran)
- [ ] Upload an MP3 without embedded art → no cover, no error in logs
- [ ] Delete a track via API → cover sidecar removed from disk
- [ ] Library list / player show vinyl fallback for legacy tracks (no 404 spam — request is gated on `cover_path`)

## Notes

- Existing tracks in your library will have no `cover_path` until they are re-synced or re-uploaded. The plan included an optional `BackfillCoverArt` task to recover art from `.original` sanitizer backups, but those backups are deleted by the existing sanitizer after a successful run, so backfill would only help in narrow cases. Skipped for this PR.